### PR TITLE
feat(dart): Dart/Flutter support — resolver, refs, barrel exports (PR A of 3)

### DIFF
--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -571,6 +571,24 @@ fn record_reference(
         // selector: if it wraps an argument_part, the previous sibling's
         // identifier text is the callee.
         "selector" => {
+            // Calls in tree-sitter-dart show up as a `selector` whose child
+            // is an `argument_part`. The callee lives in the previous
+            // sibling. Two shapes:
+            //
+            //   bare/constructor call    `Foo(args)`
+            //     identifier "Foo"         <-- prev sibling
+            //     selector "(args)"        <-- this node
+            //
+            //   method call              `obj.method(args)`
+            //     identifier "obj"
+            //     selector ".method"       <-- prev sibling (no argument_part)
+            //       unconditional_assignable_selector
+            //         identifier "method"  <-- the callee
+            //     selector "(args)"        <-- this node
+            //
+            // For the bare shape we read the identifier directly; for the
+            // method shape we descend into the prev selector to find the
+            // member identifier.
             let has_args = children(node).any(|c| c.kind() == "argument_part");
             if !has_args {
                 return;
@@ -578,16 +596,33 @@ fn record_reference(
             let Some(prev) = node.prev_sibling() else {
                 return;
             };
-            if prev.kind() != "identifier" {
-                return;
-            }
-            let name = node_text(prev, source);
-            if name.is_empty() {
+            let (callee_text, callee_line) = match prev.kind() {
+                "identifier" => (node_text(prev, source), prev.start_position().row as u32 + 1),
+                "selector" => {
+                    let Some(member) = children(prev).find_map(|c| {
+                        if c.kind() == "unconditional_assignable_selector"
+                            || c.kind() == "conditional_assignable_selector"
+                        {
+                            children(c).find(|g| g.kind() == "identifier")
+                        } else {
+                            None
+                        }
+                    }) else {
+                        return;
+                    };
+                    (
+                        node_text(member, source),
+                        member.start_position().row as u32 + 1,
+                    )
+                }
+                _ => return,
+            };
+            if callee_text.is_empty() {
                 return;
             }
             references.push(ExtractedReference {
-                name,
-                line: prev.start_position().row as u32 + 1,
+                name: callee_text,
+                line: callee_line,
                 from_symbol_idx: enclosing,
                 kind: ReferenceKind::Call,
             });
@@ -863,14 +898,11 @@ final appName = 'MyApp';
     #[ignore = "debug aid — dumps AST"]
     fn _dump_ast_for_calls() {
         let src = r#"
-class Animal {}
-class Dog {
-  final Animal parent;
-  Dog(this.parent);
-  Animal get ancestor => parent;
+void setUp() {
+  facade = SweFacade(swe, ephePath: ephePath);
+  obj.method(arg);
+  Body.Sun;
 }
-Dog adopt(Animal a) => Dog(a);
-Duration wait = Duration(seconds: 1);
 "#;
         let mut parser = Parser::new();
         parser
@@ -900,6 +932,8 @@ void helper() {}
 void main() {
   helper();
   print('hi');
+  facade = SweFacade(swe);
+  obj.method(arg);
 }
 "#;
         let result = parse_dart(source);
@@ -916,6 +950,17 @@ void main() {
         assert!(
             calls.contains(&"print"),
             "expected `print` call ref, got {calls:?}"
+        );
+        // Constructor-style call inside an assignment must be picked up.
+        assert!(
+            calls.contains(&"SweFacade"),
+            "expected `SweFacade` call ref (constructor in assignment), got {calls:?}"
+        );
+        // Method call `obj.method(arg)` — the method name (not the receiver)
+        // is the call target.
+        assert!(
+            calls.contains(&"method"),
+            "expected `method` call ref (method invocation), got {calls:?}"
         );
     }
 

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -399,16 +399,29 @@ fn extract_import(node: Node, source: &[u8]) -> Option<ExtractedImport> {
     if uri.is_empty() {
         return None;
     }
+    // Dart's `import_or_export` covers both `import '…';` and `export '…';`.
+    // A barrel library re-exports its internal files so every consumer of the
+    // barrel transitively depends on them — we record that as an edge (with
+    // is_reexport=true) so impact/blast analysis walks through the barrel.
+    let is_reexport = is_export_directive(node);
     Some(ExtractedImport {
         source: uri,
         specifiers: vec![],
-        is_reexport: false,
+        is_reexport,
     })
+}
+
+fn is_export_directive(node: Node) -> bool {
+    children(node).any(|c| matches!(c.kind(), "library_export" | "export_specification"))
 }
 
 fn find_configurable_uri(node: Node, source: &[u8]) -> Option<String> {
     for child in children(node) {
-        if child.kind() == "library_import" || child.kind() == "import_specification" {
+        if child.kind() == "library_import"
+            || child.kind() == "import_specification"
+            || child.kind() == "library_export"
+            || child.kind() == "export_specification"
+        {
             return find_configurable_uri(child, source);
         }
         if child.kind() == "configurable_uri" {
@@ -759,6 +772,30 @@ mod tests {
         assert_eq!(result.imports.len(), 1);
         assert_eq!(result.imports[0].source, "package:flutter/material.dart");
         assert!(!result.imports[0].is_reexport);
+    }
+
+    #[test]
+    fn test_export_directive_is_tracked_as_reexport() {
+        // Barrel libraries re-export internal files so downstream importers
+        // of the barrel transitively reach them. The edge must be recorded,
+        // and is_reexport must be true so consumers can tell it apart from a
+        // real `import`.
+        let result = parse_dart(
+            r#"library arrow_swe;
+
+export 'src/swe_facade.dart';
+export 'src/eph_snapshot.dart';
+"#,
+        );
+        assert_eq!(result.imports.len(), 2, "two export edges expected");
+        assert!(
+            result.imports.iter().all(|i| i.is_reexport),
+            "export directives must set is_reexport=true, got {:?}",
+            result.imports
+        );
+        let sources: Vec<&str> = result.imports.iter().map(|i| i.source.as_str()).collect();
+        assert!(sources.contains(&"src/swe_facade.dart"));
+        assert!(sources.contains(&"src/eph_snapshot.dart"));
     }
 
     #[test]

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -59,13 +59,17 @@ fn extract_from_node(
             if let Some(sym) = extract_class(node, source) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                // Sweep method bodies / field initializers for call + type
-                // references. The class itself owns references that occur
-                // directly in the header (superclass, `with`, `implements`);
-                // method-body references are attributed to the enclosing
-                // method below via a second pass on each function_body.
-                collect_references(node, source, Some(idx), references);
+                // Class-header references (superclass, `with`, `implements`)
+                // attribute to the class. Skip the body — `extract_class_body`
+                // walks each member and attributes per-method.
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["class_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -73,8 +77,14 @@ fn extract_from_node(
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Trait) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                collect_references(node, source, Some(idx), references);
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["class_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -90,8 +100,14 @@ fn extract_from_node(
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Class) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                collect_references(node, source, Some(idx), references);
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["extension_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -291,6 +307,7 @@ fn extract_class_body(
     source: &[u8],
     class_idx: usize,
     symbols: &mut Vec<ExtractedSymbol>,
+    references: &mut Vec<ExtractedReference>,
 ) {
     let body =
         children(class_node).find(|c| c.kind() == "class_body" || c.kind() == "extension_body");
@@ -303,7 +320,29 @@ fn extract_class_body(
             continue;
         }
         if let Some(sym) = extract_member(member, source, class_idx) {
+            let method_idx = symbols.len();
             symbols.push(sym);
+            // Walk this method's body (and signature) for call + type
+            // references attributed to the method itself, not the class.
+            let method_body = member
+                .child_by_field_name("body")
+                .or_else(|| children(member).find(|c| c.kind() == "function_body"));
+            if let Some(b) = method_body {
+                collect_references(b, source, Some(method_idx), references);
+            }
+            // Sweep the signature too so parameter and return types attribute
+            // to the method.
+            collect_references_skip(
+                member,
+                source,
+                Some(method_idx),
+                references,
+                &["function_body"],
+            );
+        } else {
+            // Non-method member (e.g. field with initializer): attribute any
+            // references to the enclosing class.
+            collect_references(member, source, Some(class_idx), references);
         }
     }
 }
@@ -549,21 +588,39 @@ fn node_text(node: Node, source: &[u8]) -> String {
 /// parent is itself a declaration header (class/mixin/enum/extension/type
 /// alias), to avoid recording a class as a reference to itself.
 ///
-/// References inside method bodies are attributed to the enclosing class
-/// symbol (not the individual method), matching what `extract_class_body`
-/// records as the symbol unit. This is coarser than TypeScript's
-/// per-method attribution but still produces meaningful call edges at the
-/// file level, and it keeps the initial Dart port small.
+/// References inside method bodies are attributed per-method by
+/// `extract_class_body`; this function is invoked separately on each
+/// method body with `enclosing = method_idx`. Class-level call sites pass
+/// `["class_body"]` (or `["extension_body"]`) to `collect_references_skip`
+/// so the class header sweep stops at the body boundary.
 fn collect_references(
     root: Node,
     source: &[u8],
     enclosing: Option<usize>,
     references: &mut Vec<ExtractedReference>,
 ) {
+    collect_references_skip(root, source, enclosing, references, &[]);
+}
+
+/// Like `collect_references` but does not descend into nodes whose kind is
+/// listed in `skip_kinds`. Used so that a class-level sweep can record
+/// references in the class header (superclass, `with`, `implements`) without
+/// also bleeding every method-body call into the class symbol — those are
+/// attributed per-method by `extract_class_body`.
+fn collect_references_skip(
+    root: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+    skip_kinds: &[&str],
+) {
     let mut cursor = root.walk();
     let mut stack: Vec<Node> = children(root).collect();
     while let Some(node) = stack.pop() {
         record_reference(node, source, enclosing, references);
+        if skip_kinds.contains(&node.kind()) {
+            continue;
+        }
         for child in node.children(&mut cursor) {
             stack.push(child);
         }
@@ -1065,7 +1122,7 @@ Dog adopt(Animal a) => Dog(a);
     }
 
     #[test]
-    fn attributes_references_to_enclosing_symbol() {
+    fn attributes_method_body_calls_to_method() {
         let source = r#"
 void helper() {}
 
@@ -1076,13 +1133,11 @@ class Worker {
 }
 "#;
         let result = parse_dart(source);
-        // The `helper()` call inside Worker.run should be attributed to
-        // the enclosing Worker class symbol (coarse but correct).
-        let worker_idx = result
+        let run_idx = result
             .symbols
             .iter()
-            .position(|s| s.name == "Worker")
-            .expect("Worker symbol exists");
+            .position(|s| s.name == "run")
+            .expect("run method exists");
         let helper_call = result
             .references
             .iter()
@@ -1090,8 +1145,72 @@ class Worker {
             .expect("helper call ref exists");
         assert_eq!(
             helper_call.from_symbol_idx,
-            Some(worker_idx),
-            "helper() inside Worker.run should attribute to Worker"
+            Some(run_idx),
+            "helper() inside Worker.run should attribute to run, not Worker"
+        );
+    }
+
+    #[test]
+    fn cross_class_method_call_attributes_to_caller_method() {
+        let source = r#"
+class A {
+  void foo() {}
+}
+
+class B {
+  void bar() {
+    foo();
+  }
+}
+"#;
+        let result = parse_dart(source);
+        let bar_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "bar")
+            .expect("bar method exists");
+        let b_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "B")
+            .expect("B class exists");
+        let foo_call = result
+            .references
+            .iter()
+            .find(|r| r.name == "foo" && matches!(r.kind, ReferenceKind::Call))
+            .expect("foo call ref exists");
+        assert_eq!(
+            foo_call.from_symbol_idx,
+            Some(bar_idx),
+            "foo() inside B.bar should attribute to bar (not B)"
+        );
+        assert_ne!(foo_call.from_symbol_idx, Some(b_idx));
+    }
+
+    #[test]
+    fn class_header_type_refs_attribute_to_class() {
+        let source = r#"
+abstract class Animal {}
+
+class Dog extends Animal {
+  void bark() {}
+}
+"#;
+        let result = parse_dart(source);
+        let dog_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "Dog")
+            .expect("Dog class exists");
+        let animal_ref = result
+            .references
+            .iter()
+            .find(|r| r.name == "Animal" && matches!(r.kind, ReferenceKind::TypeRef))
+            .expect("Animal type ref exists");
+        assert_eq!(
+            animal_ref.from_symbol_idx,
+            Some(dog_idx),
+            "Animal in `extends Animal` should attribute to Dog (class header)"
         );
     }
 }

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -1,7 +1,9 @@
 use tree_sitter::{Language, Node};
 
 use super::LanguageSupport;
-use crate::index::symbols::{ExtractedImport, ExtractedSymbol, ParseResult, SymbolKind};
+use crate::index::symbols::{
+    ExtractedImport, ExtractedReference, ExtractedSymbol, ParseResult, ReferenceKind, SymbolKind,
+};
 
 pub struct DartSupport;
 
@@ -21,12 +23,13 @@ impl LanguageSupport for DartSupport {
     fn extract(&self, source: &[u8], tree: &tree_sitter::Tree) -> ParseResult {
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
+        let mut references = Vec::new();
         let root = tree.root_node();
-        extract_from_node(root, source, &mut symbols, &mut imports);
+        extract_from_node(root, source, &mut symbols, &mut imports, &mut references, None);
         ParseResult {
             symbols,
             imports,
-            references: Vec::new(),
+            references,
         }
     }
 }
@@ -48,6 +51,8 @@ fn extract_from_node(
     source: &[u8],
     symbols: &mut Vec<ExtractedSymbol>,
     imports: &mut Vec<ExtractedImport>,
+    references: &mut Vec<ExtractedReference>,
+    enclosing: Option<usize>,
 ) {
     match node.kind() {
         "class_declaration" => {
@@ -55,6 +60,12 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                // Sweep method bodies / field initializers for call + type
+                // references. The class itself owns references that occur
+                // directly in the header (superclass, `with`, `implements`);
+                // method-body references are attributed to the enclosing
+                // method below via a second pass on each function_body.
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -63,12 +74,15 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
         "enum_declaration" => {
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Enum) {
+                let idx = symbols.len();
                 symbols.push(sym);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -77,12 +91,15 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
         "type_alias" => {
             if let Some(sym) = extract_type_alias(node, source) {
+                let idx = symbols.len();
                 symbols.push(sym);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -90,7 +107,19 @@ fn extract_from_node(
             if is_top_level(node)
                 && let Some(sym) = extract_function(node, source)
             {
+                let idx = symbols.len();
                 symbols.push(sym);
+                // Sweep the signature (for param/return type refs) and
+                // the adjacent function_body sibling (for call and
+                // type refs in the body). Using the shared source_file
+                // parent here would bleed references from unrelated
+                // top-level declarations into this function.
+                collect_references(node, source, Some(idx), references);
+                if let Some(body) = node.next_sibling()
+                    && body.kind() == "function_body"
+                {
+                    collect_references(body, source, Some(idx), references);
+                }
             }
             return;
         }
@@ -110,12 +139,14 @@ fn extract_from_node(
             if is_top_level(node) {
                 let kind = resolve_variable_kind(node);
                 extract_variable_list(node, source, kind, symbols);
+                collect_references(node, source, enclosing, references);
             }
             return;
         }
         "initialized_identifier_list" => {
             if is_top_level(node) {
                 extract_initialized_list(node, source, symbols);
+                collect_references(node, source, enclosing, references);
             }
             return;
         }
@@ -123,7 +154,7 @@ fn extract_from_node(
     }
 
     for child in children(node) {
-        extract_from_node(child, source, symbols, imports);
+        extract_from_node(child, source, symbols, imports, references, enclosing);
     }
 }
 
@@ -497,6 +528,125 @@ fn node_text(node: Node, source: &[u8]) -> String {
         .to_string()
 }
 
+/// Walks `root` and records call-site and type-reference edges. Dart's
+/// tree-sitter grammar exposes call sites under a handful of parent kinds
+/// (`function_expression_invocation`, `method_invocation`,
+/// `invocation_expression`, `selector`) where the callee lives in an
+/// `identifier` child. We treat a `type_identifier` as a TypeRef unless its
+/// parent is itself a declaration header (class/mixin/enum/extension/type
+/// alias), to avoid recording a class as a reference to itself.
+///
+/// References inside method bodies are attributed to the enclosing class
+/// symbol (not the individual method), matching what `extract_class_body`
+/// records as the symbol unit. This is coarser than TypeScript's
+/// per-method attribution but still produces meaningful call edges at the
+/// file level, and it keeps the initial Dart port small.
+fn collect_references(
+    root: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+) {
+    let mut cursor = root.walk();
+    let mut stack: Vec<Node> = children(root).collect();
+    while let Some(node) = stack.pop() {
+        record_reference(node, source, enclosing, references);
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+}
+
+fn record_reference(
+    node: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+) {
+    let line = node.start_position().row as u32 + 1;
+    match node.kind() {
+        // Tree-sitter-dart emits calls as two sibling nodes under the
+        // parent: an `identifier` for the callee and a `selector` that
+        // contains an `argument_part`. Detect the shape by looking at the
+        // selector: if it wraps an argument_part, the previous sibling's
+        // identifier text is the callee.
+        "selector" => {
+            let has_args = children(node).any(|c| c.kind() == "argument_part");
+            if !has_args {
+                return;
+            }
+            let Some(prev) = node.prev_sibling() else {
+                return;
+            };
+            if prev.kind() != "identifier" {
+                return;
+            }
+            let name = node_text(prev, source);
+            if name.is_empty() {
+                return;
+            }
+            references.push(ExtractedReference {
+                name,
+                line: prev.start_position().row as u32 + 1,
+                from_symbol_idx: enclosing,
+                kind: ReferenceKind::Call,
+            });
+        }
+        // Type positions: parameter annotations, field/variable types,
+        // return types. The grammar uses `type_identifier` only here;
+        // declaration headers (`class Foo`) use plain `identifier`, so no
+        // self-reference filtering is needed.
+        "type_identifier" => {
+            let name = node_text(node, source);
+            if !name.is_empty() && !is_dart_builtin_type(&name) {
+                references.push(ExtractedReference {
+                    name,
+                    line,
+                    from_symbol_idx: enclosing,
+                    kind: ReferenceKind::TypeRef,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_dart_builtin_type(name: &str) -> bool {
+    matches!(
+        name,
+        "int"
+            | "double"
+            | "num"
+            | "bool"
+            | "String"
+            | "void"
+            | "dynamic"
+            | "Object"
+            | "Null"
+            | "Never"
+            | "List"
+            | "Map"
+            | "Set"
+            | "Iterable"
+            | "Future"
+            | "Stream"
+            | "Function"
+            | "Symbol"
+            | "Type"
+            | "Record"
+            | "Enum"
+            | "Comparable"
+            | "DateTime"
+            | "Duration"
+            | "RegExp"
+            | "Uri"
+            | "BigInt"
+            | "StackTrace"
+            | "Error"
+            | "Exception"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -707,5 +857,159 @@ final appName = 'MyApp';
             .find(|i| i.source == "model.dart")
             .unwrap();
         assert!(part.is_reexport);
+    }
+
+    #[test]
+    #[ignore = "debug aid — dumps AST"]
+    fn _dump_ast_for_calls() {
+        let src = r#"
+class Animal {}
+class Dog {
+  final Animal parent;
+  Dog(this.parent);
+  Animal get ancestor => parent;
+}
+Dog adopt(Animal a) => Dog(a);
+Duration wait = Duration(seconds: 1);
+"#;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&Language::new(tree_sitter_dart::LANGUAGE))
+            .unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        fn walk(n: Node, src: &[u8], d: usize) {
+            let t: String = std::str::from_utf8(&src[n.start_byte()..n.end_byte().min(src.len())])
+                .unwrap_or("")
+                .chars()
+                .take(40)
+                .collect();
+            eprintln!("{}{} {:?}", "  ".repeat(d), n.kind(), t);
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                walk(ch, src, d + 1);
+            }
+        }
+        walk(tree.root_node(), src.as_bytes(), 0);
+    }
+
+    #[test]
+    fn extracts_call_references() {
+        let source = r#"
+void helper() {}
+
+void main() {
+  helper();
+  print('hi');
+}
+"#;
+        let result = parse_dart(source);
+        let calls: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::Call))
+            .map(|r| r.name.as_str())
+            .collect();
+        assert!(
+            calls.contains(&"helper"),
+            "expected `helper` call ref, got {calls:?}"
+        );
+        assert!(
+            calls.contains(&"print"),
+            "expected `print` call ref, got {calls:?}"
+        );
+    }
+
+    #[test]
+    fn extracts_type_references() {
+        let source = r#"
+class Greeter {
+  final Duration delay;
+  Greeter(this.delay);
+  DateTime now() => DateTime.now();
+}
+"#;
+        let result = parse_dart(source);
+        let type_refs: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::TypeRef))
+            .map(|r| r.name.as_str())
+            .collect();
+        // Duration and DateTime are Dart builtins — they must be filtered.
+        assert!(
+            !type_refs.contains(&"Duration"),
+            "builtin Duration should not be a type ref, got {type_refs:?}"
+        );
+        assert!(
+            !type_refs.contains(&"DateTime"),
+            "builtin DateTime should not be a type ref, got {type_refs:?}"
+        );
+        // Greeter is the declared class itself — its own header must not
+        // produce a self-reference.
+        let self_refs: Vec<_> = result
+            .references
+            .iter()
+            .filter(|r| r.name == "Greeter")
+            .collect();
+        assert!(
+            self_refs.is_empty(),
+            "declared class name must not appear as its own reference, got {self_refs:?}"
+        );
+    }
+
+    #[test]
+    fn extracts_user_type_references() {
+        let source = r#"
+class Animal {}
+
+class Dog {
+  final Animal parent;
+  Dog(this.parent);
+}
+
+Dog adopt(Animal a) => Dog(a);
+"#;
+        let result = parse_dart(source);
+        let type_refs: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::TypeRef))
+            .map(|r| r.name.as_str())
+            .collect();
+        assert!(
+            type_refs.contains(&"Animal"),
+            "expected `Animal` type ref, got {type_refs:?}"
+        );
+    }
+
+    #[test]
+    fn attributes_references_to_enclosing_symbol() {
+        let source = r#"
+void helper() {}
+
+class Worker {
+  void run() {
+    helper();
+  }
+}
+"#;
+        let result = parse_dart(source);
+        // The `helper()` call inside Worker.run should be attributed to
+        // the enclosing Worker class symbol (coarse but correct).
+        let worker_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "Worker")
+            .expect("Worker symbol exists");
+        let helper_call = result
+            .references
+            .iter()
+            .find(|r| r.name == "helper" && matches!(r.kind, ReferenceKind::Call))
+            .expect("helper call ref exists");
+        assert_eq!(
+            helper_call.from_symbol_idx,
+            Some(worker_idx),
+            "helper() inside Worker.run should attribute to Worker"
+        );
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -609,13 +609,20 @@ fn read_go_module(root: &Path) -> Option<String> {
 /// Resolves a Dart `import`/`part` specifier to a file path relative to `root`.
 ///
 /// Handles three specifier shapes:
-///   * `dart:io`, `dart:async`      → SDK, not in the workspace, return empty.
-///   * `package:NAME/a/b.dart`      → look up NAME in the workspace package
-///                                    map and rewrite to `<pkg-dir>/lib/a/b.dart`.
+///   * `dart:io`, `dart:async` — SDK, not in the workspace, return empty.
+///   * `package:NAME/a/b.dart` — look up NAME in the workspace package map
+///     and rewrite to `<pkg-dir>/lib/a/b.dart`.
 ///   * relative (`./x.dart`, `../x.dart`, `x.dart`) — including `part`
-///                                    directives, which always carry a
-///                                    relative URI — fall through to the
-///                                    generic relative resolver.
+///     directives, which always carry a relative URI — fall through to the
+///     generic relative resolver.
+///
+/// **Scope:** workspace-only. Only packages whose `pubspec.yaml` lives inside
+/// `root` are resolvable; path-/git-dependencies outside the workspace and
+/// pub-cache packages are intentionally ignored. We do not consult
+/// `.dart_tool/package_config.json` — it requires `pub get` to be fresh and
+/// would pull cache paths that are irrelevant for symbol indexing. A
+/// `package:` import whose package name is not in the workspace map returns
+/// no edge.
 fn resolve_dart_import(
     rel_path: &str,
     specifier: &str,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -33,6 +33,7 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     let files = walker::walk_source_files(root);
     let pool = ParserPool::new();
     let go_module = read_go_module(root);
+    let dart_packages = read_dart_packages(root);
 
     tracing::info!("found {} source files on disk", files.len());
 
@@ -168,6 +169,7 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
                 root,
                 &known_paths,
                 go_module.as_deref(),
+                Some(&dart_packages),
             );
             for target_rel in &targets {
                 if let Some(&target_id) = path_to_id.get(target_rel.as_str()) {
@@ -319,6 +321,7 @@ fn resolve_targets(
     root: &Path,
     known_files: &HashSet<String>,
     go_module: Option<&str>,
+    dart_packages: Option<&HashMap<String, String>>,
 ) -> Vec<String> {
     match language {
         "rust" => resolve_rust_import(rel_path, specifier, known_files)
@@ -328,6 +331,7 @@ fn resolve_targets(
             .into_iter()
             .collect(),
         "go" => resolve_go_import(specifier, known_files, go_module),
+        "dart" => resolve_dart_import(rel_path, specifier, root, known_files, dart_packages),
         _ => {
             let importing_file = root.join(rel_path);
             resolve_import(&importing_file, specifier, root, known_files)
@@ -600,6 +604,126 @@ fn read_go_module(root: &Path) -> Option<String> {
     })
 }
 
+// --- Dart ---
+
+/// Resolves a Dart `import`/`part` specifier to a file path relative to `root`.
+///
+/// Handles three specifier shapes:
+///   * `dart:io`, `dart:async`      → SDK, not in the workspace, return empty.
+///   * `package:NAME/a/b.dart`      → look up NAME in the workspace package
+///                                    map and rewrite to `<pkg-dir>/lib/a/b.dart`.
+///   * relative (`./x.dart`, `../x.dart`, `x.dart`) — including `part`
+///                                    directives, which always carry a
+///                                    relative URI — fall through to the
+///                                    generic relative resolver.
+fn resolve_dart_import(
+    rel_path: &str,
+    specifier: &str,
+    root: &Path,
+    known_files: &HashSet<String>,
+    dart_packages: Option<&HashMap<String, String>>,
+) -> Vec<String> {
+    if specifier.starts_with("dart:") {
+        return vec![];
+    }
+
+    if let Some(rest) = specifier.strip_prefix("package:") {
+        let packages = match dart_packages {
+            Some(p) => p,
+            None => return vec![],
+        };
+        let (name, tail) = match rest.split_once('/') {
+            Some(parts) => parts,
+            None => return vec![],
+        };
+        let pkg_dir = match packages.get(name) {
+            Some(d) => d,
+            None => return vec![],
+        };
+        let candidate = if pkg_dir.is_empty() {
+            format!("lib/{tail}")
+        } else {
+            format!("{pkg_dir}/lib/{tail}")
+        };
+        let normalized = normalize_path(Path::new(&candidate))
+            .to_string_lossy()
+            .to_string();
+        if known_files.contains(&normalized) {
+            return vec![normalized];
+        }
+        return vec![];
+    }
+
+    let importing_file = root.join(rel_path);
+    resolve_import(&importing_file, specifier, root, known_files)
+        .into_iter()
+        .collect()
+}
+
+/// Walks the workspace for `pubspec.yaml` files and returns a map from each
+/// declared package name to its directory (relative to `root`, forward-slash
+/// form, empty string for a pubspec at the root). Used by
+/// `resolve_dart_import` to translate `package:foo/…` imports to real files.
+fn read_dart_packages(root: &Path) -> HashMap<String, String> {
+    let mut packages = HashMap::new();
+    let walker = ignore::WalkBuilder::new(root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        if path.file_name().and_then(|n| n.to_str()) != Some("pubspec.yaml") {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let Some(name) = parse_pubspec_name(&content) else {
+            continue;
+        };
+
+        let rel_dir = match path.parent().and_then(|p| p.strip_prefix(root).ok()) {
+            Some(p) => p.to_string_lossy().replace('\\', "/"),
+            None => continue,
+        };
+
+        packages.insert(name, rel_dir);
+    }
+
+    packages
+}
+
+/// Extracts the top-level `name:` field from a `pubspec.yaml` body. Only
+/// unindented `name:` keys count — an indented `name:` under some other
+/// mapping must not hijack the package identity.
+fn parse_pubspec_name(pubspec: &str) -> Option<String> {
+    for raw in pubspec.lines() {
+        let line = raw.split('#').next().unwrap_or("");
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.starts_with(|c: char| c.is_whitespace()) {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("name:") {
+            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
 // --- Helpers ---
 
 fn normalize_path(path: &Path) -> std::path::PathBuf {
@@ -650,6 +774,7 @@ pub fn incremental_index(
 
     let pool = ParserPool::new();
     let go_module = read_go_module(root);
+    let dart_packages = read_dart_packages(root);
 
     let tx = conn.unchecked_transaction()?;
 
@@ -767,6 +892,7 @@ pub fn incremental_index(
                 root,
                 &known_paths,
                 go_module.as_deref(),
+                Some(&dart_packages),
             );
             for target_rel in &targets {
                 if let Some(&target_id) = path_to_id.get(target_rel.as_str()) {
@@ -1054,6 +1180,199 @@ mod tests {
         let known = HashSet::new();
         let result = resolve_go_import("pkg/utils", &known, None);
         assert!(result.is_empty());
+    }
+
+    // --- Dart resolver ---
+
+    #[test]
+    fn test_parse_pubspec_name_simple() {
+        let yaml = "name: arrow_core\nversion: 0.1.0\n";
+        assert_eq!(parse_pubspec_name(yaml), Some("arrow_core".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_quoted() {
+        assert_eq!(
+            parse_pubspec_name("name: 'arrow_core'\n"),
+            Some("arrow_core".to_string())
+        );
+        assert_eq!(
+            parse_pubspec_name("name: \"arrow_core\"\n"),
+            Some("arrow_core".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_ignores_indented() {
+        let yaml = "dev_dependencies:\n  pkg:\n    name: nested\n";
+        assert_eq!(parse_pubspec_name(yaml), None);
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_ignores_comments() {
+        let yaml = "# name: wrong\nname: right\n";
+        assert_eq!(parse_pubspec_name(yaml), Some("right".to_string()));
+    }
+
+    #[test]
+    fn test_read_dart_packages_monorepo() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("options")).unwrap();
+        fs::create_dir_all(root.join("core")).unwrap();
+        fs::write(root.join("options/pubspec.yaml"), "name: arrow_options\n").unwrap();
+        fs::write(root.join("core/pubspec.yaml"), "name: arrow_core\n").unwrap();
+
+        let packages = read_dart_packages(root);
+        assert_eq!(packages.get("arrow_options"), Some(&"options".to_string()));
+        assert_eq!(packages.get("arrow_core"), Some(&"core".to_string()));
+    }
+
+    #[test]
+    fn test_read_dart_packages_root_pubspec() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(root.join("pubspec.yaml"), "name: arrow\n").unwrap();
+
+        let packages = read_dart_packages(root);
+        assert_eq!(packages.get("arrow"), Some(&"".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_dart_import_package() {
+        let mut pkgs = HashMap::new();
+        pkgs.insert("arrow_options".to_string(), "options".to_string());
+        let mut known = HashSet::new();
+        known.insert("options/lib/src/body.dart".to_string());
+        known.insert("options/lib/arrow_options.dart".to_string());
+
+        let result = resolve_dart_import(
+            "core/lib/src/chart.dart",
+            "package:arrow_options/src/body.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["options/lib/src/body.dart".to_string()]);
+
+        let result = resolve_dart_import(
+            "core/lib/src/chart.dart",
+            "package:arrow_options/arrow_options.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["options/lib/arrow_options.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_dart_import_package_at_root() {
+        let mut pkgs = HashMap::new();
+        pkgs.insert("arrow".to_string(), "".to_string());
+        let mut known = HashSet::new();
+        known.insert("lib/src/chart.dart".to_string());
+
+        let result = resolve_dart_import(
+            "lib/main.dart",
+            "package:arrow/src/chart.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["lib/src/chart.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_dart_import_sdk_is_empty() {
+        let pkgs = HashMap::new();
+        let known = HashSet::new();
+        assert!(
+            resolve_dart_import(
+                "lib/main.dart",
+                "dart:async",
+                Path::new("/"),
+                &known,
+                Some(&pkgs)
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_resolve_dart_import_unknown_package_is_empty() {
+        let pkgs = HashMap::new();
+        let known = HashSet::new();
+        assert!(
+            resolve_dart_import(
+                "lib/main.dart",
+                "package:flutter/material.dart",
+                Path::new("/"),
+                &known,
+                Some(&pkgs)
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_resolve_dart_import_relative() {
+        let pkgs = HashMap::new();
+        let mut known = HashSet::new();
+        known.insert("lib/src/helper.dart".to_string());
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let result = resolve_dart_import(
+            "lib/src/main.dart",
+            "./helper.dart",
+            root,
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["lib/src/helper.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_full_index_resolves_dart_package_imports() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join("options/lib/src")).unwrap();
+        fs::create_dir_all(root.join("core/lib/src")).unwrap();
+        fs::write(root.join("options/pubspec.yaml"), "name: arrow_options\n").unwrap();
+        fs::write(root.join("core/pubspec.yaml"), "name: arrow_core\n").unwrap();
+        fs::write(
+            root.join("options/lib/src/body.dart"),
+            "enum Body { sun, moon }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("core/lib/src/chart.dart"),
+            "import 'package:arrow_options/src/body.dart';\n\
+             class Chart { Body? sun; }\n",
+        )
+        .unwrap();
+
+        let conn = storage::open_in_memory().unwrap();
+        full_index(&conn, root, true).unwrap();
+
+        let chart_id = read::get_file_by_path(&conn, "core/lib/src/chart.dart")
+            .unwrap()
+            .unwrap()
+            .id;
+        let body_id = read::get_file_by_path(&conn, "options/lib/src/body.dart")
+            .unwrap()
+            .unwrap()
+            .id;
+
+        let edges = read::get_all_edges(&conn).unwrap();
+        let has_edge = edges
+            .iter()
+            .any(|e| e.0 == chart_id && e.1 == body_id);
+        assert!(
+            has_edge,
+            "expected chart.dart → body.dart import edge, got edges {edges:?}"
+        );
     }
 
     // --- Integration tests ---

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2623,7 +2623,7 @@ impl QartezServer {
 
     #[tool(
         name = "qartez_project",
-        description = "Run project commands (test, build, lint, typecheck) with auto-detected toolchain (Cargo, npm/bun/yarn, Go, Python, Make). Use action='info' to see detected commands. Use filter for targeted runs (e.g., test name).",
+        description = "Run project commands (test, build, lint, typecheck) with auto-detected toolchain (Cargo, npm/bun/yarn/pnpm, Go, Python, Dart/Flutter, Maven, Gradle, sbt, Ruby, Make). Use action='info' to see detected commands. Use filter for targeted runs (e.g., test name).",
         annotations(
             title = "Run Project Command",
             read_only_hint = false,
@@ -2641,7 +2641,7 @@ impl QartezServer {
 
         if action == ProjectAction::Info {
             if all_toolchains.is_empty() {
-                return Err("No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, Gemfile, Makefile".to_string());
+                return Err("No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, pubspec.yaml, Gemfile, Makefile, pom.xml, build.gradle(.kts), build.sbt".to_string());
             }
             let mut out = String::new();
             for (i, tc) in all_toolchains.iter().enumerate() {
@@ -2669,7 +2669,7 @@ impl QartezServer {
         }
 
         let tc = all_toolchains.into_iter().next().ok_or_else(|| {
-            "No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, Gemfile, Makefile".to_string()
+            "No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, pubspec.yaml, Gemfile, Makefile, pom.xml, build.gradle(.kts), build.sbt".to_string()
         })?;
 
         if action == ProjectAction::Run {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -959,6 +959,7 @@ fn compute_cochange_pairs(
 fn is_test_path(path: &str) -> bool {
     // Directory-based patterns (all languages)
     if path.starts_with("tests/")
+        || path.starts_with("test/")
         || path.starts_with("benches/")
         || path.starts_with("__tests__/")
         || path.starts_with("spec/")
@@ -966,6 +967,7 @@ fn is_test_path(path: &str) -> bool {
         return true;
     }
     if path.contains("/tests/")
+        || path.contains("/test/")
         || path.contains("/benches/")
         || path.contains("/__tests__/")
         || path.contains("/spec/")
@@ -982,6 +984,10 @@ fn is_test_path(path: &str) -> bool {
         }
         // Go: _test.go
         if name.ends_with("_test.go") {
+            return true;
+        }
+        // Dart: _test.dart
+        if name.ends_with("_test.dart") {
             return true;
         }
         // TypeScript/JavaScript: .test.ts, .spec.ts, .test.tsx, .spec.tsx,
@@ -3487,7 +3493,7 @@ impl QartezServer {
         };
 
         let mut out = format!(
-            "files={} (src={}/test={}) loc={}/{} syms={} edges={} indexed={}/{}\n",
+            "files={} (src={}/test={}) loc={}/{} syms={} edges={} with_symbols={}/{}\n",
             file_count,
             src_files.len(),
             test_files.len(),

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -130,6 +130,35 @@ pub fn detect_all_toolchains(project_root: &Path) -> Vec<DetectedToolchain> {
         });
     }
 
+    if project_root.join("pubspec.yaml").exists() {
+        let pubspec = std::fs::read_to_string(project_root.join("pubspec.yaml")).unwrap_or_default();
+        let is_flutter = pubspec_uses_flutter(&pubspec);
+        let has_build_runner = pubspec.contains("build_runner:");
+        let driver = if is_flutter { "flutter" } else { "dart" };
+
+        let build_cmd = if has_build_runner {
+            vec![
+                "dart".into(),
+                "run".into(),
+                "build_runner".into(),
+                "build".into(),
+                "--delete-conflicting-outputs".into(),
+            ]
+        } else {
+            vec![driver.into(), "pub".into(), "get".into()]
+        };
+
+        toolchains.push(DetectedToolchain {
+            name: if is_flutter { "flutter".into() } else { "dart".into() },
+            build_tool: driver.into(),
+            test_cmd: vec![driver.into(), "test".into()],
+            build_cmd,
+            lint_cmd: Some(vec![driver.into(), "analyze".into()]),
+            // `dart analyze` covers static type checking — no separate typechecker.
+            typecheck_cmd: Some(vec![driver.into(), "analyze".into()]),
+        });
+    }
+
     if project_root.join("Makefile").exists() {
         toolchains.push(DetectedToolchain {
             name: "make".to_string(),
@@ -157,6 +186,43 @@ pub fn binary_available(name: &str) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+fn pubspec_uses_flutter(pubspec: &str) -> bool {
+    // Flutter projects declare `flutter:` under `dependencies:` with `sdk: flutter`,
+    // or include a top-level `flutter:` configuration block. Either signal is enough.
+    let mut in_deps = false;
+    let mut saw_flutter_key = false;
+    for raw in pubspec.lines() {
+        let line = raw.split('#').next().unwrap_or("");
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let indent = trimmed.len() - trimmed.trim_start().len();
+        let body = trimmed.trim_start();
+
+        if indent == 0 {
+            in_deps = matches!(body, "dependencies:" | "dev_dependencies:");
+            if body == "flutter:" {
+                return true;
+            }
+            saw_flutter_key = false;
+            continue;
+        }
+
+        if in_deps && indent == 2 && body == "flutter:" {
+            saw_flutter_key = true;
+            continue;
+        }
+        if saw_flutter_key && indent >= 4 && body.starts_with("sdk:") && body.contains("flutter") {
+            return true;
+        }
+        if indent <= 2 {
+            saw_flutter_key = false;
+        }
+    }
+    false
 }
 
 fn detect_node_package_manager(project_root: &Path) -> String {
@@ -425,6 +491,77 @@ mod tests {
 
         let tc = detect_toolchain(dir.path()).unwrap();
         assert_eq!(tc.name, "scala");
+    }
+
+    #[test]
+    fn test_detect_dart_library() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_lib\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart");
+        assert_eq!(tc.build_tool, "dart");
+        assert_eq!(tc.test_cmd, vec!["dart", "test"]);
+        assert_eq!(tc.build_cmd, vec!["dart", "pub", "get"]);
+        assert_eq!(tc.lint_cmd.unwrap(), vec!["dart", "analyze"]);
+        assert_eq!(tc.typecheck_cmd.unwrap(), vec!["dart", "analyze"]);
+    }
+
+    #[test]
+    fn test_detect_dart_with_build_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_lib\ndev_dependencies:\n  build_runner: ^2.4.0\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart");
+        assert_eq!(
+            tc.build_cmd,
+            vec![
+                "dart",
+                "run",
+                "build_runner",
+                "build",
+                "--delete-conflicting-outputs",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_detect_flutter_via_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_app\ndependencies:\n  flutter:\n    sdk: flutter\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "flutter");
+        assert_eq!(tc.build_tool, "flutter");
+        assert_eq!(tc.test_cmd, vec!["flutter", "test"]);
+        assert_eq!(tc.build_cmd, vec!["flutter", "pub", "get"]);
+        assert_eq!(tc.lint_cmd.unwrap(), vec!["flutter", "analyze"]);
+    }
+
+    #[test]
+    fn test_detect_flutter_via_top_level_block() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_app\nflutter:\n  uses-material-design: true\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "flutter");
     }
 
     #[test]

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -189,9 +189,12 @@ pub fn binary_available(name: &str) -> bool {
 }
 
 fn pubspec_uses_flutter(pubspec: &str) -> bool {
-    // Flutter projects declare `flutter:` under `dependencies:` with `sdk: flutter`,
-    // or include a top-level `flutter:` configuration block. Either signal is enough.
-    let mut in_deps = false;
+    // Flutter projects declare `flutter:` under *runtime* `dependencies:` with
+    // `sdk: flutter`, or include a top-level `flutter:` configuration block.
+    // `dev_dependencies:` is explicitly excluded — pure-Dart packages commonly
+    // test with `flutter_test`, and we must not flip those to the Flutter
+    // toolchain.
+    let mut in_runtime_deps = false;
     let mut saw_flutter_key = false;
     for raw in pubspec.lines() {
         let line = raw.split('#').next().unwrap_or("");
@@ -203,7 +206,7 @@ fn pubspec_uses_flutter(pubspec: &str) -> bool {
         let body = trimmed.trim_start();
 
         if indent == 0 {
-            in_deps = matches!(body, "dependencies:" | "dev_dependencies:");
+            in_runtime_deps = body == "dependencies:";
             if body == "flutter:" {
                 return true;
             }
@@ -211,7 +214,7 @@ fn pubspec_uses_flutter(pubspec: &str) -> bool {
             continue;
         }
 
-        if in_deps && indent == 2 && body == "flutter:" {
+        if in_runtime_deps && indent == 2 && body == "flutter:" {
             saw_flutter_key = true;
             continue;
         }
@@ -549,6 +552,28 @@ mod tests {
         assert_eq!(tc.test_cmd, vec!["flutter", "test"]);
         assert_eq!(tc.build_cmd, vec!["flutter", "pub", "get"]);
         assert_eq!(tc.lint_cmd.unwrap(), vec!["flutter", "analyze"]);
+    }
+
+    #[test]
+    fn test_flutter_sdk_under_dev_dependencies_stays_dart() {
+        // Pure-Dart libraries commonly depend on `flutter_test` for their
+        // widget tests, which pulls `flutter: sdk: flutter` into
+        // `dev_dependencies`. The toolchain must stay `dart`, not flip to
+        // `flutter`.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: pure_dart_lib\n\
+             dev_dependencies:\n\
+             \u{0020}\u{0020}flutter:\n\
+             \u{0020}\u{0020}\u{0020}\u{0020}sdk: flutter\n\
+             \u{0020}\u{0020}flutter_test:\n\
+             \u{0020}\u{0020}\u{0020}\u{0020}sdk: flutter\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart", "dev-only flutter must stay dart toolchain");
     }
 
     #[test]


### PR DESCRIPTION
Split of #3, rebased on current `main` (v0.2.0). This is **PR A** — all Dart-only work. Stands alone off `main`.

Companion PRs:
- **PR B** (`feat/resolver-and-cochange`): cross-cutting resolver + cochange changes. Stacks on this one.
- **PR C** (`fix/background-indexing-startup`): unrelated startup fix. Independent.

## What's in this PR

### 1. Dart/Flutter toolchain detection
- `detect_toolchain` recognizes `pubspec.yaml` and distinguishes pure-Dart libraries from Flutter apps via a top-level `flutter:` block or a runtime `dependencies: flutter: sdk: flutter` entry.
- `build_runner:` in the pubspec switches `build_cmd` to `dart run build_runner build --delete-conflicting-outputs` — matches what freezed/json_serializable packages actually need.

### 2. Cross-package import resolver
- `resolve_dart_import` handles `dart:`, `package:NAME/…`, and relative URIs.
- Workspace `pubspec.yaml` files are walked once per index pass; `package:foo/bar.dart` resolves to `<pkg-dir>/lib/bar.dart` when `foo` is declared in the workspace. SDK + pub-cache deps are intentionally out of scope (see rustdoc).
- End-to-end test (`test_full_index_resolves_dart_package_imports`) drives `full_index` against a synthetic monorepo and asserts the edge lands in the DB.

### 3. Call-site + type-reference extraction
- Walks `function_body` subtrees to capture `helper()`, `print('…')`, `Foo(args)` (constructor-in-assignment), and `obj.method(arg)` call shapes.
- `type_identifier` in parameter/return/field positions produces TypeRef edges. Built-in Dart types (`int`, `String`, `Duration`, `DateTime`, `Future`, …) are filtered.

### 4. Per-method call attribution in class bodies
- Class/mixin/extension bodies now walk each member individually with a fresh `enclosing = method_idx`, so `qartez_calls` on a Dart method returns the actual method-level callers instead of the coarse class-level fallback.

### 5. Barrel `export` edges
- `find_configurable_uri` now descends into `library_export` / `export_specification` nodes, and the edge is flagged `is_reexport: true`.
- Before: `library arrow_swe; export 'src/swe_facade.dart';` emitted **zero** import edges — every barrel-re-exported file reported 0 direct importers despite being reachable from every consumer of the barrel.
- Regression test: `test_export_directive_is_tracked_as_reexport`.

### 6. dev-dependency Flutter misclassification
- `pubspec_uses_flutter` now only treats runtime `dependencies:` as flutter-indicating. Previously, any pure-Dart library that used `flutter_test` (which pulls `flutter: sdk: flutter` into `dev_dependencies:`) was flipped to the Flutter toolchain.
- Regression test: `test_flutter_sdk_under_dev_dependencies_stays_dart`.

### 7. Dart test-path classification + accurate stats label
- `is_test_path` recognizes Dart's singular `test/` convention (including `<pkg>/test/` in monorepos) and the `_test.dart` suffix.
- Stats label renamed from misleading `indexed=N/M` to `with_symbols=N/M` (export-only barrel files are legitimately "files with no symbols" and shouldn't count as unindexed).

### 8. Workspace-scope rustdoc
- `resolve_dart_import` rustdoc now states the workspace-only contract explicitly and explains why `.dart_tool/package_config.json` is not consulted.

## Test plan

- [x] `cargo test --release` — all pass on current `main` (v0.2.0) base
- [x] `cargo clippy --release --all-targets` — no new warnings
- [x] End-to-end smoke on a real Dart monorepo (arrow, 110 files): `qartez_stats`, `qartez_map`, `qartez_impact`, `qartez_refs`, `qartez_outline`, `qartez_hotspots`, `qartez_unused`, `qartez_cochange`, `qartez_context`, `qartez_deps` all return sensible results
- [x] Barrel-export regression verified: previously 0 direct importers, now reports importers via the re-export chain
- [x] Flutter-toolchain misclassification verified: a pure-Dart library using `flutter_test` stays on the `dart` toolchain