### PR TITLE
feat(resolver): kind-filter + receiver-type heuristic; fix(cochange): phantom files (PR B of 3)

### DIFF
--- a/src/git/cochange.rs
+++ b/src/git/cochange.rs
@@ -6,7 +6,8 @@ use rusqlite::Connection;
 use tracing::{debug, info, warn};
 
 use crate::error::Result;
-use crate::storage::write::{get_or_create_file, upsert_cochange_n};
+use crate::storage::read::get_file_by_path;
+use crate::storage::write::upsert_cochange_n;
 
 pub struct CoChangeConfig {
     pub commit_limit: u32,
@@ -119,16 +120,27 @@ pub fn analyze_cochanges(conn: &Connection, root: &Path, config: &CoChangeConfig
 
     let tx = conn.unchecked_transaction()?;
     let mut written = 0u32;
+    let mut skipped = 0u32;
     for ((path_a, path_b), count) in &pair_counts {
-        let file_a = get_or_create_file(&tx, path_a)?;
-        let file_b = get_or_create_file(&tx, path_b)?;
-        upsert_cochange_n(&tx, file_a, file_b, *count)?;
+        // Only record co-changes between files that currently exist on disk
+        // (i.e. were inserted by full_index). Paths seen only in git history
+        // — renames, deletes, moves — are dropped rather than resurrected as
+        // phantom rows with zero size/mtime.
+        let (Some(a), Some(b)) = (
+            get_file_by_path(&tx, path_a)?,
+            get_file_by_path(&tx, path_b)?,
+        ) else {
+            skipped += 1;
+            continue;
+        };
+        upsert_cochange_n(&tx, a.id, b.id, *count)?;
         written += 1;
     }
 
-    // Write per-file change counts into the files table.
+    // Write per-file change counts into the files table. Historical-only
+    // paths are dropped here for the same reason.
     for (path, count) in &file_change_counts {
-        if let Some(file) = crate::storage::read::get_file_by_path(&tx, path)? {
+        if let Some(file) = get_file_by_path(&tx, path)? {
             tx.execute(
                 "UPDATE files SET change_count = ?1 WHERE id = ?2",
                 rusqlite::params![*count as i64, file.id],
@@ -139,8 +151,9 @@ pub fn analyze_cochanges(conn: &Connection, root: &Path, config: &CoChangeConfig
     tx.commit()?;
 
     info!(
-        "Co-change analysis complete: {} pairs, {} file change counts written",
+        "Co-change analysis complete: {} pairs written ({} skipped: historical-only paths), {} file change counts written",
         written,
+        skipped,
         file_change_counts.len()
     );
     Ok(())
@@ -345,7 +358,10 @@ mod tests {
     }
 
     #[test]
-    fn test_unindexed_files_are_auto_created() {
+    fn test_unregistered_paths_are_skipped() {
+        // Files that appear only in git history — never indexed from disk —
+        // must not be resurrected as phantom rows. Co-change pairs touching
+        // such paths are simply dropped.
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         let repo = init_repo(dir);
@@ -358,18 +374,25 @@ mod tests {
             "commit with non-indexed file",
         );
 
+        // Only a.rs and b.rs are registered (simulating files indexed from disk).
+        // deploy.yaml is seen in git history but not on disk.
         register_files(&conn, &["src/a.rs", "src/b.rs"]);
 
         analyze_cochanges(&conn, dir, &CoChangeConfig::default()).unwrap();
 
+        // Only the (a, b) pair should be recorded. (a, deploy) and (b, deploy)
+        // are skipped because deploy.yaml is not in the files table.
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM co_changes", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(count, 3);
+        assert_eq!(count, 1);
 
-        let yaml_file = storage::read::get_file_by_path(&conn, "deploy.yaml")
-            .unwrap()
-            .expect("deploy.yaml should be auto-created");
-        assert_eq!(yaml_file.language, "yaml");
+        // deploy.yaml must NOT have been inserted.
+        assert!(
+            storage::read::get_file_by_path(&conn, "deploy.yaml")
+                .unwrap()
+                .is_none(),
+            "historical-only paths must not be resurrected as phantom rows"
+        );
     }
 }

--- a/src/index/languages/c_lang.rs
+++ b/src/index/languages/c_lang.rs
@@ -340,6 +340,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -358,6 +359,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/cpp.rs
+++ b/src/index/languages/cpp.rs
@@ -234,6 +234,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -248,6 +249,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -270,6 +272,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/csharp.rs
+++ b/src/index/languages/csharp.rs
@@ -327,6 +327,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -348,6 +349,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -373,6 +375,7 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -451,6 +454,7 @@ fn record_return_type(
                 line: ret.start_position().row as u32 + 1,
                 from_symbol_idx: enclosing,
                 kind: ReferenceKind::TypeRef,
+                receiver_type_hint: None,
             });
         }
     }

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -571,6 +571,24 @@ fn record_reference(
         // selector: if it wraps an argument_part, the previous sibling's
         // identifier text is the callee.
         "selector" => {
+            // Calls in tree-sitter-dart show up as a `selector` whose child
+            // is an `argument_part`. The callee lives in the previous
+            // sibling. Two shapes:
+            //
+            //   bare/constructor call    `Foo(args)`
+            //     identifier "Foo"         <-- prev sibling
+            //     selector "(args)"        <-- this node
+            //
+            //   method call              `obj.method(args)`
+            //     identifier "obj"
+            //     selector ".method"       <-- prev sibling (no argument_part)
+            //       unconditional_assignable_selector
+            //         identifier "method"  <-- the callee
+            //     selector "(args)"        <-- this node
+            //
+            // For the bare shape we read the identifier directly; for the
+            // method shape we descend into the prev selector to find the
+            // member identifier.
             let has_args = children(node).any(|c| c.kind() == "argument_part");
             if !has_args {
                 return;
@@ -578,16 +596,33 @@ fn record_reference(
             let Some(prev) = node.prev_sibling() else {
                 return;
             };
-            if prev.kind() != "identifier" {
-                return;
-            }
-            let name = node_text(prev, source);
-            if name.is_empty() {
+            let (callee_text, callee_line) = match prev.kind() {
+                "identifier" => (node_text(prev, source), prev.start_position().row as u32 + 1),
+                "selector" => {
+                    let Some(member) = children(prev).find_map(|c| {
+                        if c.kind() == "unconditional_assignable_selector"
+                            || c.kind() == "conditional_assignable_selector"
+                        {
+                            children(c).find(|g| g.kind() == "identifier")
+                        } else {
+                            None
+                        }
+                    }) else {
+                        return;
+                    };
+                    (
+                        node_text(member, source),
+                        member.start_position().row as u32 + 1,
+                    )
+                }
+                _ => return,
+            };
+            if callee_text.is_empty() {
                 return;
             }
             references.push(ExtractedReference {
-                name,
-                line: prev.start_position().row as u32 + 1,
+                name: callee_text,
+                line: callee_line,
                 from_symbol_idx: enclosing,
                 kind: ReferenceKind::Call,
             });
@@ -863,14 +898,11 @@ final appName = 'MyApp';
     #[ignore = "debug aid — dumps AST"]
     fn _dump_ast_for_calls() {
         let src = r#"
-class Animal {}
-class Dog {
-  final Animal parent;
-  Dog(this.parent);
-  Animal get ancestor => parent;
+void setUp() {
+  facade = SweFacade(swe, ephePath: ephePath);
+  obj.method(arg);
+  Body.Sun;
 }
-Dog adopt(Animal a) => Dog(a);
-Duration wait = Duration(seconds: 1);
 "#;
         let mut parser = Parser::new();
         parser
@@ -900,6 +932,8 @@ void helper() {}
 void main() {
   helper();
   print('hi');
+  facade = SweFacade(swe);
+  obj.method(arg);
 }
 "#;
         let result = parse_dart(source);
@@ -916,6 +950,17 @@ void main() {
         assert!(
             calls.contains(&"print"),
             "expected `print` call ref, got {calls:?}"
+        );
+        // Constructor-style call inside an assignment must be picked up.
+        assert!(
+            calls.contains(&"SweFacade"),
+            "expected `SweFacade` call ref (constructor in assignment), got {calls:?}"
+        );
+        // Method call `obj.method(arg)` — the method name (not the receiver)
+        // is the call target.
+        assert!(
+            calls.contains(&"method"),
+            "expected `method` call ref (method invocation), got {calls:?}"
         );
     }
 

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -399,16 +399,29 @@ fn extract_import(node: Node, source: &[u8]) -> Option<ExtractedImport> {
     if uri.is_empty() {
         return None;
     }
+    // Dart's `import_or_export` covers both `import '…';` and `export '…';`.
+    // A barrel library re-exports its internal files so every consumer of the
+    // barrel transitively depends on them — we record that as an edge (with
+    // is_reexport=true) so impact/blast analysis walks through the barrel.
+    let is_reexport = is_export_directive(node);
     Some(ExtractedImport {
         source: uri,
         specifiers: vec![],
-        is_reexport: false,
+        is_reexport,
     })
+}
+
+fn is_export_directive(node: Node) -> bool {
+    children(node).any(|c| matches!(c.kind(), "library_export" | "export_specification"))
 }
 
 fn find_configurable_uri(node: Node, source: &[u8]) -> Option<String> {
     for child in children(node) {
-        if child.kind() == "library_import" || child.kind() == "import_specification" {
+        if child.kind() == "library_import"
+            || child.kind() == "import_specification"
+            || child.kind() == "library_export"
+            || child.kind() == "export_specification"
+        {
             return find_configurable_uri(child, source);
         }
         if child.kind() == "configurable_uri" {
@@ -759,6 +772,30 @@ mod tests {
         assert_eq!(result.imports.len(), 1);
         assert_eq!(result.imports[0].source, "package:flutter/material.dart");
         assert!(!result.imports[0].is_reexport);
+    }
+
+    #[test]
+    fn test_export_directive_is_tracked_as_reexport() {
+        // Barrel libraries re-export internal files so downstream importers
+        // of the barrel transitively reach them. The edge must be recorded,
+        // and is_reexport must be true so consumers can tell it apart from a
+        // real `import`.
+        let result = parse_dart(
+            r#"library arrow_swe;
+
+export 'src/swe_facade.dart';
+export 'src/eph_snapshot.dart';
+"#,
+        );
+        assert_eq!(result.imports.len(), 2, "two export edges expected");
+        assert!(
+            result.imports.iter().all(|i| i.is_reexport),
+            "export directives must set is_reexport=true, got {:?}",
+            result.imports
+        );
+        let sources: Vec<&str> = result.imports.iter().map(|i| i.source.as_str()).collect();
+        assert!(sources.contains(&"src/swe_facade.dart"));
+        assert!(sources.contains(&"src/eph_snapshot.dart"));
     }
 
     #[test]

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -59,13 +59,17 @@ fn extract_from_node(
             if let Some(sym) = extract_class(node, source) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                // Sweep method bodies / field initializers for call + type
-                // references. The class itself owns references that occur
-                // directly in the header (superclass, `with`, `implements`);
-                // method-body references are attributed to the enclosing
-                // method below via a second pass on each function_body.
-                collect_references(node, source, Some(idx), references);
+                // Class-header references (superclass, `with`, `implements`)
+                // attribute to the class. Skip the body — `extract_class_body`
+                // walks each member and attributes per-method.
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["class_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -73,8 +77,14 @@ fn extract_from_node(
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Trait) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                collect_references(node, source, Some(idx), references);
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["class_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -90,8 +100,14 @@ fn extract_from_node(
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Class) {
                 let idx = symbols.len();
                 symbols.push(sym);
-                extract_class_body(node, source, idx, symbols);
-                collect_references(node, source, Some(idx), references);
+                collect_references_skip(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &["extension_body"],
+                );
+                extract_class_body(node, source, idx, symbols, references);
             }
             return;
         }
@@ -291,6 +307,7 @@ fn extract_class_body(
     source: &[u8],
     class_idx: usize,
     symbols: &mut Vec<ExtractedSymbol>,
+    references: &mut Vec<ExtractedReference>,
 ) {
     let body =
         children(class_node).find(|c| c.kind() == "class_body" || c.kind() == "extension_body");
@@ -303,7 +320,29 @@ fn extract_class_body(
             continue;
         }
         if let Some(sym) = extract_member(member, source, class_idx) {
+            let method_idx = symbols.len();
             symbols.push(sym);
+            // Walk this method's body (and signature) for call + type
+            // references attributed to the method itself, not the class.
+            let method_body = member
+                .child_by_field_name("body")
+                .or_else(|| children(member).find(|c| c.kind() == "function_body"));
+            if let Some(b) = method_body {
+                collect_references(b, source, Some(method_idx), references);
+            }
+            // Sweep the signature too so parameter and return types attribute
+            // to the method.
+            collect_references_skip(
+                member,
+                source,
+                Some(method_idx),
+                references,
+                &["function_body"],
+            );
+        } else {
+            // Non-method member (e.g. field with initializer): attribute any
+            // references to the enclosing class.
+            collect_references(member, source, Some(class_idx), references);
         }
     }
 }
@@ -549,21 +588,39 @@ fn node_text(node: Node, source: &[u8]) -> String {
 /// parent is itself a declaration header (class/mixin/enum/extension/type
 /// alias), to avoid recording a class as a reference to itself.
 ///
-/// References inside method bodies are attributed to the enclosing class
-/// symbol (not the individual method), matching what `extract_class_body`
-/// records as the symbol unit. This is coarser than TypeScript's
-/// per-method attribution but still produces meaningful call edges at the
-/// file level, and it keeps the initial Dart port small.
+/// References inside method bodies are attributed per-method by
+/// `extract_class_body`; this function is invoked separately on each
+/// method body with `enclosing = method_idx`. Class-level call sites pass
+/// `["class_body"]` (or `["extension_body"]`) to `collect_references_skip`
+/// so the class header sweep stops at the body boundary.
 fn collect_references(
     root: Node,
     source: &[u8],
     enclosing: Option<usize>,
     references: &mut Vec<ExtractedReference>,
 ) {
+    collect_references_skip(root, source, enclosing, references, &[]);
+}
+
+/// Like `collect_references` but does not descend into nodes whose kind is
+/// listed in `skip_kinds`. Used so that a class-level sweep can record
+/// references in the class header (superclass, `with`, `implements`) without
+/// also bleeding every method-body call into the class symbol — those are
+/// attributed per-method by `extract_class_body`.
+fn collect_references_skip(
+    root: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+    skip_kinds: &[&str],
+) {
     let mut cursor = root.walk();
     let mut stack: Vec<Node> = children(root).collect();
     while let Some(node) = stack.pop() {
         record_reference(node, source, enclosing, references);
+        if skip_kinds.contains(&node.kind()) {
+            continue;
+        }
         for child in node.children(&mut cursor) {
             stack.push(child);
         }
@@ -1065,7 +1122,7 @@ Dog adopt(Animal a) => Dog(a);
     }
 
     #[test]
-    fn attributes_references_to_enclosing_symbol() {
+    fn attributes_method_body_calls_to_method() {
         let source = r#"
 void helper() {}
 
@@ -1076,13 +1133,11 @@ class Worker {
 }
 "#;
         let result = parse_dart(source);
-        // The `helper()` call inside Worker.run should be attributed to
-        // the enclosing Worker class symbol (coarse but correct).
-        let worker_idx = result
+        let run_idx = result
             .symbols
             .iter()
-            .position(|s| s.name == "Worker")
-            .expect("Worker symbol exists");
+            .position(|s| s.name == "run")
+            .expect("run method exists");
         let helper_call = result
             .references
             .iter()
@@ -1090,8 +1145,72 @@ class Worker {
             .expect("helper call ref exists");
         assert_eq!(
             helper_call.from_symbol_idx,
-            Some(worker_idx),
-            "helper() inside Worker.run should attribute to Worker"
+            Some(run_idx),
+            "helper() inside Worker.run should attribute to run, not Worker"
+        );
+    }
+
+    #[test]
+    fn cross_class_method_call_attributes_to_caller_method() {
+        let source = r#"
+class A {
+  void foo() {}
+}
+
+class B {
+  void bar() {
+    foo();
+  }
+}
+"#;
+        let result = parse_dart(source);
+        let bar_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "bar")
+            .expect("bar method exists");
+        let b_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "B")
+            .expect("B class exists");
+        let foo_call = result
+            .references
+            .iter()
+            .find(|r| r.name == "foo" && matches!(r.kind, ReferenceKind::Call))
+            .expect("foo call ref exists");
+        assert_eq!(
+            foo_call.from_symbol_idx,
+            Some(bar_idx),
+            "foo() inside B.bar should attribute to bar (not B)"
+        );
+        assert_ne!(foo_call.from_symbol_idx, Some(b_idx));
+    }
+
+    #[test]
+    fn class_header_type_refs_attribute_to_class() {
+        let source = r#"
+abstract class Animal {}
+
+class Dog extends Animal {
+  void bark() {}
+}
+"#;
+        let result = parse_dart(source);
+        let dog_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "Dog")
+            .expect("Dog class exists");
+        let animal_ref = result
+            .references
+            .iter()
+            .find(|r| r.name == "Animal" && matches!(r.kind, ReferenceKind::TypeRef))
+            .expect("Animal type ref exists");
+        assert_eq!(
+            animal_ref.from_symbol_idx,
+            Some(dog_idx),
+            "Animal in `extends Animal` should attribute to Dog (class header)"
         );
     }
 }

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -1,7 +1,9 @@
 use tree_sitter::{Language, Node};
 
 use super::LanguageSupport;
-use crate::index::symbols::{ExtractedImport, ExtractedSymbol, ParseResult, SymbolKind};
+use crate::index::symbols::{
+    ExtractedImport, ExtractedReference, ExtractedSymbol, ParseResult, ReferenceKind, SymbolKind,
+};
 
 pub struct DartSupport;
 
@@ -21,12 +23,13 @@ impl LanguageSupport for DartSupport {
     fn extract(&self, source: &[u8], tree: &tree_sitter::Tree) -> ParseResult {
         let mut symbols = Vec::new();
         let mut imports = Vec::new();
+        let mut references = Vec::new();
         let root = tree.root_node();
-        extract_from_node(root, source, &mut symbols, &mut imports);
+        extract_from_node(root, source, &mut symbols, &mut imports, &mut references, None);
         ParseResult {
             symbols,
             imports,
-            references: Vec::new(),
+            references,
         }
     }
 }
@@ -48,6 +51,8 @@ fn extract_from_node(
     source: &[u8],
     symbols: &mut Vec<ExtractedSymbol>,
     imports: &mut Vec<ExtractedImport>,
+    references: &mut Vec<ExtractedReference>,
+    enclosing: Option<usize>,
 ) {
     match node.kind() {
         "class_declaration" => {
@@ -55,6 +60,12 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                // Sweep method bodies / field initializers for call + type
+                // references. The class itself owns references that occur
+                // directly in the header (superclass, `with`, `implements`);
+                // method-body references are attributed to the enclosing
+                // method below via a second pass on each function_body.
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -63,12 +74,15 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
         "enum_declaration" => {
             if let Some(sym) = extract_named_decl(node, source, SymbolKind::Enum) {
+                let idx = symbols.len();
                 symbols.push(sym);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -77,12 +91,15 @@ fn extract_from_node(
                 let idx = symbols.len();
                 symbols.push(sym);
                 extract_class_body(node, source, idx, symbols);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
         "type_alias" => {
             if let Some(sym) = extract_type_alias(node, source) {
+                let idx = symbols.len();
                 symbols.push(sym);
+                collect_references(node, source, Some(idx), references);
             }
             return;
         }
@@ -90,7 +107,19 @@ fn extract_from_node(
             if is_top_level(node)
                 && let Some(sym) = extract_function(node, source)
             {
+                let idx = symbols.len();
                 symbols.push(sym);
+                // Sweep the signature (for param/return type refs) and
+                // the adjacent function_body sibling (for call and
+                // type refs in the body). Using the shared source_file
+                // parent here would bleed references from unrelated
+                // top-level declarations into this function.
+                collect_references(node, source, Some(idx), references);
+                if let Some(body) = node.next_sibling()
+                    && body.kind() == "function_body"
+                {
+                    collect_references(body, source, Some(idx), references);
+                }
             }
             return;
         }
@@ -110,12 +139,14 @@ fn extract_from_node(
             if is_top_level(node) {
                 let kind = resolve_variable_kind(node);
                 extract_variable_list(node, source, kind, symbols);
+                collect_references(node, source, enclosing, references);
             }
             return;
         }
         "initialized_identifier_list" => {
             if is_top_level(node) {
                 extract_initialized_list(node, source, symbols);
+                collect_references(node, source, enclosing, references);
             }
             return;
         }
@@ -123,7 +154,7 @@ fn extract_from_node(
     }
 
     for child in children(node) {
-        extract_from_node(child, source, symbols, imports);
+        extract_from_node(child, source, symbols, imports, references, enclosing);
     }
 }
 
@@ -497,6 +528,125 @@ fn node_text(node: Node, source: &[u8]) -> String {
         .to_string()
 }
 
+/// Walks `root` and records call-site and type-reference edges. Dart's
+/// tree-sitter grammar exposes call sites under a handful of parent kinds
+/// (`function_expression_invocation`, `method_invocation`,
+/// `invocation_expression`, `selector`) where the callee lives in an
+/// `identifier` child. We treat a `type_identifier` as a TypeRef unless its
+/// parent is itself a declaration header (class/mixin/enum/extension/type
+/// alias), to avoid recording a class as a reference to itself.
+///
+/// References inside method bodies are attributed to the enclosing class
+/// symbol (not the individual method), matching what `extract_class_body`
+/// records as the symbol unit. This is coarser than TypeScript's
+/// per-method attribution but still produces meaningful call edges at the
+/// file level, and it keeps the initial Dart port small.
+fn collect_references(
+    root: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+) {
+    let mut cursor = root.walk();
+    let mut stack: Vec<Node> = children(root).collect();
+    while let Some(node) = stack.pop() {
+        record_reference(node, source, enclosing, references);
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+}
+
+fn record_reference(
+    node: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+) {
+    let line = node.start_position().row as u32 + 1;
+    match node.kind() {
+        // Tree-sitter-dart emits calls as two sibling nodes under the
+        // parent: an `identifier` for the callee and a `selector` that
+        // contains an `argument_part`. Detect the shape by looking at the
+        // selector: if it wraps an argument_part, the previous sibling's
+        // identifier text is the callee.
+        "selector" => {
+            let has_args = children(node).any(|c| c.kind() == "argument_part");
+            if !has_args {
+                return;
+            }
+            let Some(prev) = node.prev_sibling() else {
+                return;
+            };
+            if prev.kind() != "identifier" {
+                return;
+            }
+            let name = node_text(prev, source);
+            if name.is_empty() {
+                return;
+            }
+            references.push(ExtractedReference {
+                name,
+                line: prev.start_position().row as u32 + 1,
+                from_symbol_idx: enclosing,
+                kind: ReferenceKind::Call,
+            });
+        }
+        // Type positions: parameter annotations, field/variable types,
+        // return types. The grammar uses `type_identifier` only here;
+        // declaration headers (`class Foo`) use plain `identifier`, so no
+        // self-reference filtering is needed.
+        "type_identifier" => {
+            let name = node_text(node, source);
+            if !name.is_empty() && !is_dart_builtin_type(&name) {
+                references.push(ExtractedReference {
+                    name,
+                    line,
+                    from_symbol_idx: enclosing,
+                    kind: ReferenceKind::TypeRef,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_dart_builtin_type(name: &str) -> bool {
+    matches!(
+        name,
+        "int"
+            | "double"
+            | "num"
+            | "bool"
+            | "String"
+            | "void"
+            | "dynamic"
+            | "Object"
+            | "Null"
+            | "Never"
+            | "List"
+            | "Map"
+            | "Set"
+            | "Iterable"
+            | "Future"
+            | "Stream"
+            | "Function"
+            | "Symbol"
+            | "Type"
+            | "Record"
+            | "Enum"
+            | "Comparable"
+            | "DateTime"
+            | "Duration"
+            | "RegExp"
+            | "Uri"
+            | "BigInt"
+            | "StackTrace"
+            | "Error"
+            | "Exception"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -707,5 +857,159 @@ final appName = 'MyApp';
             .find(|i| i.source == "model.dart")
             .unwrap();
         assert!(part.is_reexport);
+    }
+
+    #[test]
+    #[ignore = "debug aid — dumps AST"]
+    fn _dump_ast_for_calls() {
+        let src = r#"
+class Animal {}
+class Dog {
+  final Animal parent;
+  Dog(this.parent);
+  Animal get ancestor => parent;
+}
+Dog adopt(Animal a) => Dog(a);
+Duration wait = Duration(seconds: 1);
+"#;
+        let mut parser = Parser::new();
+        parser
+            .set_language(&Language::new(tree_sitter_dart::LANGUAGE))
+            .unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        fn walk(n: Node, src: &[u8], d: usize) {
+            let t: String = std::str::from_utf8(&src[n.start_byte()..n.end_byte().min(src.len())])
+                .unwrap_or("")
+                .chars()
+                .take(40)
+                .collect();
+            eprintln!("{}{} {:?}", "  ".repeat(d), n.kind(), t);
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                walk(ch, src, d + 1);
+            }
+        }
+        walk(tree.root_node(), src.as_bytes(), 0);
+    }
+
+    #[test]
+    fn extracts_call_references() {
+        let source = r#"
+void helper() {}
+
+void main() {
+  helper();
+  print('hi');
+}
+"#;
+        let result = parse_dart(source);
+        let calls: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::Call))
+            .map(|r| r.name.as_str())
+            .collect();
+        assert!(
+            calls.contains(&"helper"),
+            "expected `helper` call ref, got {calls:?}"
+        );
+        assert!(
+            calls.contains(&"print"),
+            "expected `print` call ref, got {calls:?}"
+        );
+    }
+
+    #[test]
+    fn extracts_type_references() {
+        let source = r#"
+class Greeter {
+  final Duration delay;
+  Greeter(this.delay);
+  DateTime now() => DateTime.now();
+}
+"#;
+        let result = parse_dart(source);
+        let type_refs: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::TypeRef))
+            .map(|r| r.name.as_str())
+            .collect();
+        // Duration and DateTime are Dart builtins — they must be filtered.
+        assert!(
+            !type_refs.contains(&"Duration"),
+            "builtin Duration should not be a type ref, got {type_refs:?}"
+        );
+        assert!(
+            !type_refs.contains(&"DateTime"),
+            "builtin DateTime should not be a type ref, got {type_refs:?}"
+        );
+        // Greeter is the declared class itself — its own header must not
+        // produce a self-reference.
+        let self_refs: Vec<_> = result
+            .references
+            .iter()
+            .filter(|r| r.name == "Greeter")
+            .collect();
+        assert!(
+            self_refs.is_empty(),
+            "declared class name must not appear as its own reference, got {self_refs:?}"
+        );
+    }
+
+    #[test]
+    fn extracts_user_type_references() {
+        let source = r#"
+class Animal {}
+
+class Dog {
+  final Animal parent;
+  Dog(this.parent);
+}
+
+Dog adopt(Animal a) => Dog(a);
+"#;
+        let result = parse_dart(source);
+        let type_refs: Vec<&str> = result
+            .references
+            .iter()
+            .filter(|r| matches!(r.kind, ReferenceKind::TypeRef))
+            .map(|r| r.name.as_str())
+            .collect();
+        assert!(
+            type_refs.contains(&"Animal"),
+            "expected `Animal` type ref, got {type_refs:?}"
+        );
+    }
+
+    #[test]
+    fn attributes_references_to_enclosing_symbol() {
+        let source = r#"
+void helper() {}
+
+class Worker {
+  void run() {
+    helper();
+  }
+}
+"#;
+        let result = parse_dart(source);
+        // The `helper()` call inside Worker.run should be attributed to
+        // the enclosing Worker class symbol (coarse but correct).
+        let worker_idx = result
+            .symbols
+            .iter()
+            .position(|s| s.name == "Worker")
+            .expect("Worker symbol exists");
+        let helper_call = result
+            .references
+            .iter()
+            .find(|r| r.name == "helper" && matches!(r.kind, ReferenceKind::Call))
+            .expect("helper call ref exists");
+        assert_eq!(
+            helper_call.from_symbol_idx,
+            Some(worker_idx),
+            "helper() inside Worker.run should attribute to Worker"
+        );
     }
 }

--- a/src/index/languages/dart.rs
+++ b/src/index/languages/dart.rs
@@ -1,9 +1,17 @@
+use std::collections::HashMap;
+
 use tree_sitter::{Language, Node};
 
 use super::LanguageSupport;
 use crate::index::symbols::{
     ExtractedImport, ExtractedReference, ExtractedSymbol, ParseResult, ReferenceKind, SymbolKind,
 };
+
+/// Identifier → declared type name, populated from formal parameters, typed
+/// locals, and (for methods) enclosing-class fields. Used by the resolver's
+/// receiver-type heuristic: a call `receiver.method(...)` emits a hint when
+/// `receiver` is a bare identifier found in this map.
+type ScopeEnv = HashMap<String, String>;
 
 pub struct DartSupport;
 
@@ -130,11 +138,28 @@ fn extract_from_node(
                 // type refs in the body). Using the shared source_file
                 // parent here would bleed references from unrelated
                 // top-level declarations into this function.
-                collect_references(node, source, Some(idx), references);
+                let mut env = ScopeEnv::new();
+                collect_param_types(node, source, &mut env);
+                collect_references_scoped(
+                    node,
+                    source,
+                    Some(idx),
+                    references,
+                    &[],
+                    Some(&env),
+                );
                 if let Some(body) = node.next_sibling()
                     && body.kind() == "function_body"
                 {
-                    collect_references(body, source, Some(idx), references);
+                    collect_local_types(body, source, &mut env);
+                    collect_references_scoped(
+                        body,
+                        source,
+                        Some(idx),
+                        references,
+                        &[],
+                        Some(&env),
+                    );
                 }
             }
             return;
@@ -315,6 +340,10 @@ fn extract_class_body(
         Some(b) => b,
         None => return,
     };
+    // Build the class-level field type environment once; every method below
+    // layers its params + locals on top of this base.
+    let mut class_fields = ScopeEnv::new();
+    collect_class_field_types(class_node, source, &mut class_fields);
     for member in children(body) {
         if member.kind() != "class_member" {
             continue;
@@ -327,22 +356,42 @@ fn extract_class_body(
             let method_body = member
                 .child_by_field_name("body")
                 .or_else(|| children(member).find(|c| c.kind() == "function_body"));
+            let mut method_env = class_fields.clone();
+            collect_param_types(member, source, &mut method_env);
             if let Some(b) = method_body {
-                collect_references(b, source, Some(method_idx), references);
+                collect_local_types(b, source, &mut method_env);
+                collect_references_scoped(
+                    b,
+                    source,
+                    Some(method_idx),
+                    references,
+                    &[],
+                    Some(&method_env),
+                );
             }
             // Sweep the signature too so parameter and return types attribute
             // to the method.
-            collect_references_skip(
+            collect_references_scoped(
                 member,
                 source,
                 Some(method_idx),
                 references,
                 &["function_body"],
+                Some(&method_env),
             );
         } else {
             // Non-method member (e.g. field with initializer): attribute any
-            // references to the enclosing class.
-            collect_references(member, source, Some(class_idx), references);
+            // references to the enclosing class. Field initializers can see
+            // sibling field types (useful for `this.x` patterns) so pass the
+            // class env.
+            collect_references_scoped(
+                member,
+                source,
+                Some(class_idx),
+                references,
+                &[],
+                Some(&class_fields),
+            );
         }
     }
 }
@@ -599,7 +648,7 @@ fn collect_references(
     enclosing: Option<usize>,
     references: &mut Vec<ExtractedReference>,
 ) {
-    collect_references_skip(root, source, enclosing, references, &[]);
+    collect_references_scoped(root, source, enclosing, references, &[], None);
 }
 
 /// Like `collect_references` but does not descend into nodes whose kind is
@@ -614,10 +663,21 @@ fn collect_references_skip(
     references: &mut Vec<ExtractedReference>,
     skip_kinds: &[&str],
 ) {
+    collect_references_scoped(root, source, enclosing, references, skip_kinds, None);
+}
+
+fn collect_references_scoped(
+    root: Node,
+    source: &[u8],
+    enclosing: Option<usize>,
+    references: &mut Vec<ExtractedReference>,
+    skip_kinds: &[&str],
+    env: Option<&ScopeEnv>,
+) {
     let mut cursor = root.walk();
     let mut stack: Vec<Node> = children(root).collect();
     while let Some(node) = stack.pop() {
-        record_reference(node, source, enclosing, references);
+        record_reference(node, source, enclosing, references, env);
         if skip_kinds.contains(&node.kind()) {
             continue;
         }
@@ -632,6 +692,7 @@ fn record_reference(
     source: &[u8],
     enclosing: Option<usize>,
     references: &mut Vec<ExtractedReference>,
+    env: Option<&ScopeEnv>,
 ) {
     let line = node.start_position().row as u32 + 1;
     match node.kind() {
@@ -666,8 +727,12 @@ fn record_reference(
             let Some(prev) = node.prev_sibling() else {
                 return;
             };
-            let (callee_text, callee_line) = match prev.kind() {
-                "identifier" => (node_text(prev, source), prev.start_position().row as u32 + 1),
+            let (callee_text, callee_line, receiver_type_hint) = match prev.kind() {
+                "identifier" => (
+                    node_text(prev, source),
+                    prev.start_position().row as u32 + 1,
+                    None,
+                ),
                 "selector" => {
                     let Some(member) = children(prev).find_map(|c| {
                         if c.kind() == "unconditional_assignable_selector"
@@ -680,9 +745,24 @@ fn record_reference(
                     }) else {
                         return;
                     };
+                    // Receiver hint: walk back one more sibling past the
+                    // dot-selector. For `foo.method()` that sibling is the
+                    // bare `identifier "foo"`. Skip cases where the receiver
+                    // is anything else (a `this`, another selector chain,
+                    // parenthesized expression) — those belong to option (c)
+                    // full inference.
+                    let hint = prev.prev_sibling().and_then(|recv| {
+                        if recv.kind() == "identifier" {
+                            let name = node_text(recv, source);
+                            env.and_then(|e| e.get(&name)).cloned()
+                        } else {
+                            None
+                        }
+                    });
                     (
                         node_text(member, source),
                         member.start_position().row as u32 + 1,
+                        hint,
                     )
                 }
                 _ => return,
@@ -695,6 +775,7 @@ fn record_reference(
                 line: callee_line,
                 from_symbol_idx: enclosing,
                 kind: ReferenceKind::Call,
+                receiver_type_hint,
             });
         }
         // Type positions: parameter annotations, field/variable types,
@@ -709,10 +790,145 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }
         _ => {}
+    }
+}
+
+/// Collect `field_name -> type_name` entries from a class/mixin/extension
+/// body. Walks each `class_member`'s leading `declaration` subtree; a field
+/// is a declaration whose first `type_identifier` child (non-builtin) is
+/// followed by an `initialized_identifier_list`. Methods are skipped because
+/// their `declaration` carries a `function_signature` / `method_signature`
+/// instead of a typed identifier list.
+fn collect_class_field_types(class_node: Node, source: &[u8], env: &mut ScopeEnv) {
+    let Some(body) = children(class_node)
+        .find(|c| c.kind() == "class_body" || c.kind() == "extension_body")
+    else {
+        return;
+    };
+    for member in children(body) {
+        if member.kind() != "class_member" {
+            continue;
+        }
+        // A field member wraps a `declaration` whose sibling is `;`. Method
+        // members wrap a `method_signature`. Skip anything without a bare
+        // declaration.
+        let Some(decl) = children(member).find(|c| c.kind() == "declaration") else {
+            continue;
+        };
+        // Method declarations nest a `function_signature`/`getter_signature`/etc.
+        // Field declarations do not.
+        let has_sig = children(decl).any(|c| {
+            matches!(
+                c.kind(),
+                "function_signature"
+                    | "method_signature"
+                    | "getter_signature"
+                    | "setter_signature"
+                    | "constructor_signature"
+                    | "factory_constructor_signature"
+            )
+        });
+        if has_sig {
+            continue;
+        }
+        let type_name = children(decl)
+            .find(|c| c.kind() == "type_identifier")
+            .map(|c| node_text(c, source));
+        let Some(type_name) = type_name else { continue };
+        if type_name.is_empty() || is_dart_builtin_type(&type_name) {
+            continue;
+        }
+        // Field names live under `initialized_identifier_list` →
+        // `initialized_identifier` → `identifier`. Static/final field lists
+        // use `static_final_declaration_list` with the same leaf shape.
+        for list in children(decl) {
+            let list_kind = list.kind();
+            if list_kind != "initialized_identifier_list"
+                && list_kind != "static_final_declaration_list"
+            {
+                continue;
+            }
+            for init in children(list) {
+                let ident = match init.kind() {
+                    "initialized_identifier" => children(init).find(|c| c.kind() == "identifier"),
+                    "static_final_declaration" => children(init).find(|c| c.kind() == "identifier"),
+                    _ => None,
+                };
+                if let Some(id) = ident {
+                    let name = node_text(id, source);
+                    if !name.is_empty() {
+                        env.insert(name, type_name.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Walk a `formal_parameter_list` (or any node containing one) and insert
+/// `param_name -> type_name` entries. Dart's tree-sitter emits
+/// `formal_parameter` with a direct `type_identifier` child (the annotation)
+/// and an `identifier` child (the parameter name). Untyped parameters and
+/// `this.x` constructor params are silently skipped.
+fn collect_param_types(sig_node: Node, source: &[u8], env: &mut ScopeEnv) {
+    let mut cursor = sig_node.walk();
+    let mut stack: Vec<Node> = vec![sig_node];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "formal_parameter" {
+            let type_name = children(n)
+                .find(|c| c.kind() == "type_identifier")
+                .map(|c| node_text(c, source));
+            let var_name = children(n)
+                .find(|c| c.kind() == "identifier")
+                .map(|c| node_text(c, source));
+            if let (Some(t), Some(v)) = (type_name, var_name)
+                && !t.is_empty()
+                && !v.is_empty()
+                && !is_dart_builtin_type(&t)
+            {
+                env.insert(v, t);
+            }
+            continue;
+        }
+        for c in n.children(&mut cursor) {
+            stack.push(c);
+        }
+    }
+}
+
+/// Walk a function body and insert `local_name -> type_name` for typed locals
+/// declared via `final T x = ...;`, `T x = ...;`, or `const T x = ...;`. The
+/// relevant AST shape is `initialized_variable_definition` with direct
+/// `type_identifier` and `identifier` children.
+fn collect_local_types(body: Node, source: &[u8], env: &mut ScopeEnv) {
+    let mut cursor = body.walk();
+    let mut stack: Vec<Node> = vec![body];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "initialized_variable_definition" {
+            let type_name = children(n)
+                .find(|c| c.kind() == "type_identifier")
+                .map(|c| node_text(c, source));
+            let var_name = children(n)
+                .find(|c| c.kind() == "identifier")
+                .map(|c| node_text(c, source));
+            if let (Some(t), Some(v)) = (type_name, var_name)
+                && !t.is_empty()
+                && !v.is_empty()
+                && !is_dart_builtin_type(&t)
+            {
+                env.insert(v, t);
+            }
+            // Still descend — nested closures may declare further typed
+            // locals we want to pick up.
+        }
+        for c in n.children(&mut cursor) {
+            stack.push(c);
+        }
     }
 }
 
@@ -990,6 +1206,35 @@ final appName = 'MyApp';
 
     #[test]
     #[ignore = "debug aid — dumps AST"]
+    fn _dump_ast_for_typed_scope() {
+        let src = r#"
+class Foo { void doit() {} }
+class Bar {
+  final Foo foo;
+  Bar(this.foo);
+  void run(Foo other) {
+    foo.doit();
+    other.doit();
+    final Foo local = Foo();
+    local.doit();
+  }
+}
+"#;
+        let mut parser = Parser::new();
+        parser.set_language(&Language::new(tree_sitter_dart::LANGUAGE)).unwrap();
+        let tree = parser.parse(src, None).unwrap();
+        fn w(n: Node, src: &[u8], d: usize) {
+            let t: String = std::str::from_utf8(&src[n.start_byte()..n.end_byte().min(src.len())])
+                .unwrap_or("").chars().take(60).collect();
+            eprintln!("{}{} {:?}", "  ".repeat(d), n.kind(), t);
+            let mut c = n.walk();
+            for ch in n.children(&mut c) { w(ch, src, d + 1); }
+        }
+        w(tree.root_node(), src.as_bytes(), 0);
+    }
+
+    #[test]
+    #[ignore = "debug aid — dumps AST"]
     fn _dump_ast_for_calls() {
         let src = r#"
 void setUp() {
@@ -1211,6 +1456,127 @@ class Dog extends Animal {
             animal_ref.from_symbol_idx,
             Some(dog_idx),
             "Animal in `extends Animal` should attribute to Dog (class header)"
+        );
+    }
+
+    fn call_ref<'a>(result: &'a ParseResult, name: &str) -> &'a ExtractedReference {
+        result
+            .references
+            .iter()
+            .find(|r| r.name == name && matches!(r.kind, ReferenceKind::Call))
+            .unwrap_or_else(|| panic!("expected call ref to `{name}`"))
+    }
+
+    #[test]
+    fn typed_local_populates_receiver_hint() {
+        let source = r#"
+class Foo { void doit() {} }
+
+void run() {
+  final Foo local = Foo();
+  local.doit();
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "doit");
+        assert_eq!(
+            call.receiver_type_hint.as_deref(),
+            Some("Foo"),
+            "local.doit() should carry Foo receiver hint"
+        );
+    }
+
+    #[test]
+    fn typed_parameter_populates_receiver_hint() {
+        let source = r#"
+class Foo { void doit() {} }
+
+void run(Foo other) {
+  other.doit();
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "doit");
+        assert_eq!(
+            call.receiver_type_hint.as_deref(),
+            Some("Foo"),
+            "parameter `Foo other` should carry Foo receiver hint at other.doit()"
+        );
+    }
+
+    #[test]
+    fn typed_field_populates_receiver_hint() {
+        let source = r#"
+class Foo { void doit() {} }
+
+class Bar {
+  final Foo foo;
+  Bar(this.foo);
+  void run() {
+    foo.doit();
+  }
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "doit");
+        assert_eq!(
+            call.receiver_type_hint.as_deref(),
+            Some("Foo"),
+            "class field `Foo foo` should carry Foo hint at foo.doit()"
+        );
+    }
+
+    #[test]
+    fn untyped_receiver_leaves_hint_none() {
+        let source = r#"
+class Foo { void doit() {} }
+
+void run() {
+  var x = Foo();
+  x.doit();
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "doit");
+        assert!(
+            call.receiver_type_hint.is_none(),
+            "untyped `var x` must not produce a receiver hint, got {:?}",
+            call.receiver_type_hint
+        );
+    }
+
+    #[test]
+    fn bare_call_has_no_receiver_hint() {
+        let source = r#"
+void helper() {}
+
+void run() {
+  helper();
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "helper");
+        assert!(
+            call.receiver_type_hint.is_none(),
+            "bare calls have no receiver; hint must stay None"
+        );
+    }
+
+    #[test]
+    fn builtin_typed_receiver_is_skipped() {
+        // `String` is filtered by is_dart_builtin_type; even though we know
+        // the type, emitting a hint for it is pointless — there is no
+        // user-defined symbol named `String` in the project index.
+        let source = r#"
+void run(String s) {
+  s.trim();
+}
+"#;
+        let result = parse_dart(source);
+        let call = call_ref(&result, "trim");
+        assert!(
+            call.receiver_type_hint.is_none(),
+            "builtin types must not emit hints"
         );
     }
 }

--- a/src/index/languages/dockerfile.rs
+++ b/src/index/languages/dockerfile.rs
@@ -148,6 +148,7 @@ impl LanguageSupport for DockerfileSupport {
                         line: line_num,
                         from_symbol_idx: None,
                         kind: ReferenceKind::Use,
+                        receiver_type_hint: None,
                     });
                 }
             }

--- a/src/index/languages/go.rs
+++ b/src/index/languages/go.rs
@@ -127,6 +127,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -145,6 +146,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/hcl.rs
+++ b/src/index/languages/hcl.rs
@@ -371,6 +371,7 @@ fn extract_refs_from_text(
                 line,
                 from_symbol_idx: enclosing_idx,
                 kind: ReferenceKind::Use,
+                receiver_type_hint: None,
             });
         }
     }
@@ -387,6 +388,7 @@ fn extract_refs_from_text(
                 line,
                 from_symbol_idx: enclosing_idx,
                 kind: ReferenceKind::Use,
+                receiver_type_hint: None,
             });
         }
     }
@@ -403,6 +405,7 @@ fn extract_refs_from_text(
                 line,
                 from_symbol_idx: enclosing_idx,
                 kind: ReferenceKind::Use,
+                receiver_type_hint: None,
             });
         }
     }
@@ -416,6 +419,7 @@ fn extract_refs_from_text(
                 line,
                 from_symbol_idx: enclosing_idx,
                 kind: ReferenceKind::Use,
+                receiver_type_hint: None,
             });
         }
     }
@@ -441,6 +445,7 @@ fn extract_refs_from_text(
                 line,
                 from_symbol_idx: enclosing_idx,
                 kind: ReferenceKind::Use,
+                receiver_type_hint: None,
             });
         }
     }

--- a/src/index/languages/helm.rs
+++ b/src/index/languages/helm.rs
@@ -83,6 +83,7 @@ impl LanguageSupport for HelmSupport {
                     line,
                     from_symbol_idx: None,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/java.rs
+++ b/src/index/languages/java.rs
@@ -131,6 +131,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -151,6 +152,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -172,6 +174,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/kotlin.rs
+++ b/src/index/languages/kotlin.rs
@@ -285,6 +285,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -307,6 +308,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Use,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -336,6 +338,7 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/php.rs
+++ b/src/index/languages/php.rs
@@ -156,6 +156,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -170,6 +171,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -184,6 +186,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -205,6 +208,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/python.rs
+++ b/src/index/languages/python.rs
@@ -147,6 +147,7 @@ fn record_reference(
                 line: node.start_position().row as u32 + 1,
                 from_symbol_idx: enclosing,
                 kind: ReferenceKind::Call,
+                receiver_type_hint: None,
             });
         }
     }

--- a/src/index/languages/ruby.rs
+++ b/src/index/languages/ruby.rs
@@ -167,6 +167,7 @@ fn record_reference(
             line: node.start_position().row as u32 + 1,
             from_symbol_idx: enclosing,
             kind: ReferenceKind::Call,
+            receiver_type_hint: None,
         });
     }
 }

--- a/src/index/languages/rust_lang.rs
+++ b/src/index/languages/rust_lang.rs
@@ -152,6 +152,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -173,6 +174,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -196,6 +198,7 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/scala.rs
+++ b/src/index/languages/scala.rs
@@ -353,6 +353,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -372,6 +373,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Use,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -391,6 +393,7 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/swift.rs
+++ b/src/index/languages/swift.rs
@@ -153,6 +153,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::Call,
+                    receiver_type_hint: None,
                 });
             }
         }
@@ -171,6 +172,7 @@ fn record_reference(
                     line: node.start_position().row as u32 + 1,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/typescript.rs
+++ b/src/index/languages/typescript.rs
@@ -146,6 +146,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -159,6 +160,7 @@ fn record_reference(
                         line,
                         from_symbol_idx: enclosing,
                         kind: ReferenceKind::Call,
+                        receiver_type_hint: None,
                     });
                 }
             }
@@ -181,6 +183,7 @@ fn record_reference(
                     line,
                     from_symbol_idx: enclosing,
                     kind: ReferenceKind::TypeRef,
+                    receiver_type_hint: None,
                 });
             }
         }

--- a/src/index/languages/yaml.rs
+++ b/src/index/languages/yaml.rs
@@ -228,6 +228,7 @@ fn extract_needs_refs(job_mapping: Node, source: &[u8], references: &mut Vec<Ext
                     line: pair.start_position().row as u32 + 1,
                     from_symbol_idx: None,
                     kind: ReferenceKind::Use,
+                    receiver_type_hint: None,
                 });
             } else if let Some(value_node) = pair.child_by_field_name("value") {
                 collect_sequence_values(value_node, source, |val, line| {
@@ -236,6 +237,7 @@ fn extract_needs_refs(job_mapping: Node, source: &[u8], references: &mut Vec<Ext
                         line,
                         from_symbol_idx: None,
                         kind: ReferenceKind::Use,
+                        receiver_type_hint: None,
                     });
                 });
             }
@@ -348,6 +350,7 @@ fn extract_gitlab_ci(
                         line: pair.start_position().row as u32 + 1,
                         from_symbol_idx: None,
                         kind: ReferenceKind::Use,
+                        receiver_type_hint: None,
                     });
                 }
 
@@ -425,6 +428,7 @@ fn extract_docker_compose(
                             line,
                             from_symbol_idx: None,
                             kind: ReferenceKind::Use,
+                            receiver_type_hint: None,
                         });
                     });
                     if let Some(deps_mapping) = find_block_mapping_recursive(deps_node) {
@@ -435,6 +439,7 @@ fn extract_docker_compose(
                                     line: dep_pair.start_position().row as u32 + 1,
                                     from_symbol_idx: None,
                                     kind: ReferenceKind::Use,
+                                    receiver_type_hint: None,
                                 });
                             }
                         }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -217,10 +217,11 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
 /// Ambiguous names that match many symbols and no import are dropped to
 /// keep the edge count manageable on large codebases.
 /// Candidate entry in the resolver's name index: symbol id, its file id,
-/// and its declared symbol kind. Kind is stored so the resolver can filter
-/// candidates by reference kind — a Call cannot target a variable or
-/// field; a TypeRef cannot target a method.
-type Candidate = (i64, i64, String);
+/// its declared symbol kind, and its parent symbol id (when the symbol is
+/// nested, e.g. a method inside a class). Kind lets the resolver filter
+/// candidates by reference kind. `parent_id` lets the receiver-type
+/// heuristic narrow a method call to the class it was declared in.
+type Candidate = (i64, i64, String, Option<i64>);
 
 /// Returns true if a symbol of `sym_kind` is a plausible target for a
 /// reference of `ref_kind`. Unknown kinds fall through conservatively
@@ -259,15 +260,26 @@ fn resolve_symbol_references(
     indexed: &[IndexedFile],
     imports_by_file: &HashMap<i64, HashSet<i64>>,
 ) -> Result<()> {
-    // (name -> [(symbol_id, file_id, kind)]) built once for the whole project.
+    // (name -> [(symbol_id, file_id, kind, parent_id)]) built once for the
+    // whole project. `type_by_name` is a parallel index restricted to
+    // type-like symbols; the receiver-type heuristic walks it to resolve a
+    // hint like `Foo` to the set of symbol ids declaring a class/struct/
+    // enum/interface/trait/type named `Foo`.
     let all_syms = read::get_all_symbols_with_path(conn)?;
     let mut name_index: HashMap<String, Vec<Candidate>> =
         HashMap::with_capacity(all_syms.len());
+    let mut type_by_name: HashMap<String, HashSet<i64>> = HashMap::new();
     for (sym, _path) in &all_syms {
         name_index
             .entry(sym.name.clone())
             .or_default()
-            .push((sym.id, sym.file_id, sym.kind.clone()));
+            .push((sym.id, sym.file_id, sym.kind.clone(), sym.parent_id));
+        if matches!(
+            sym.kind.as_str(),
+            "class" | "struct" | "enum" | "interface" | "trait" | "type"
+        ) {
+            type_by_name.entry(sym.name.clone()).or_default().insert(sym.id);
+        }
     }
 
     let mut batch: Vec<(i64, i64, &'static str)> = Vec::new();
@@ -276,6 +288,7 @@ fn resolve_symbol_references(
     let mut dropped_no_candidate = 0usize;
     let mut dropped_ambiguous = 0usize;
     let mut resolved_by_kind_filter = 0usize;
+    let mut resolved_by_receiver_type = 0usize;
 
     for entry in indexed {
         let empty_imports = HashSet::new();
@@ -312,7 +325,7 @@ fn resolve_symbol_references(
             // plausible target given the call-vs-type context.
             let filtered: Vec<&Candidate> = raw_candidates
                 .iter()
-                .filter(|(_, _, k)| kind_is_compatible(reference.kind, k))
+                .filter(|(_, _, k, _)| kind_is_compatible(reference.kind, k))
                 .collect();
             let narrowed_by_kind =
                 !filtered.is_empty() && filtered.len() < raw_candidates.len();
@@ -325,23 +338,51 @@ fn resolve_symbol_references(
                 filtered
             };
 
-            // Priority 1: target lives in the same file as the caller.
-            let mut picked: Vec<i64> = candidates
-                .iter()
-                .filter(|(sid, fid, _)| *fid == entry.file_id && *sid != from_id)
-                .map(|(sid, _, _)| *sid)
-                .collect();
+            // Priority 1 (receiver type): if the extractor attached a
+            // receiver-type hint (e.g. Dart's `Foo foo; foo.method()`),
+            // narrow to candidates whose `parent_id` points at a symbol
+            // named by the hint. This runs before the same-file/import
+            // cascade because a typed receiver is stronger evidence than
+            // any proximity heuristic: even if another class with the
+            // same method name lives in the same file, the hint tells us
+            // which one the programmer meant. Falls through when zero or
+            // multiple candidates match (v1 stays conservative).
+            let mut picked: Vec<i64> = Vec::new();
+            let mut via_receiver = false;
+            if let Some(type_name) = reference.receiver_type_hint.as_deref()
+                && let Some(type_ids) = type_by_name.get(type_name)
+            {
+                let hit: Vec<i64> = candidates
+                    .iter()
+                    .filter_map(|(sid, _, _, pid)| {
+                        pid.filter(|p| type_ids.contains(p)).map(|_| *sid)
+                    })
+                    .collect();
+                if hit.len() == 1 {
+                    picked = hit;
+                    via_receiver = true;
+                }
+            }
 
-            // Priority 2: target lives in a file this caller imports from.
+            // Priority 2: target lives in the same file as the caller.
             if picked.is_empty() {
                 picked = candidates
                     .iter()
-                    .filter(|(_, fid, _)| imported.contains(fid))
-                    .map(|(sid, _, _)| *sid)
+                    .filter(|(sid, fid, _, _)| *fid == entry.file_id && *sid != from_id)
+                    .map(|(sid, _, _, _)| *sid)
                     .collect();
             }
 
-            // Priority 3: unique global match. Ambiguous global names are
+            // Priority 3: target lives in a file this caller imports from.
+            if picked.is_empty() {
+                picked = candidates
+                    .iter()
+                    .filter(|(_, fid, _, _)| imported.contains(fid))
+                    .map(|(sid, _, _, _)| *sid)
+                    .collect();
+            }
+
+            // Priority 4: unique global match. Ambiguous global names are
             // dropped — with no import evidence and multiple candidates
             // there is no principled way to pick, and keeping them all
             // would bury the signal under noise on large projects.
@@ -354,6 +395,9 @@ fn resolve_symbol_references(
                 }
             }
 
+            if via_receiver {
+                resolved_by_receiver_type += 1;
+            }
             if narrowed_by_kind {
                 resolved_by_kind_filter += 1;
             }
@@ -368,9 +412,10 @@ fn resolve_symbol_references(
     write::insert_symbol_refs(conn, &batch)?;
 
     tracing::info!(
-        "symbol references: {} resolved ({} via kind filter), {} dropped (no enclosing), {} dropped (no candidate), {} dropped (ambiguous)",
+        "symbol references: {} resolved ({} via kind filter, {} via receiver type), {} dropped (no enclosing), {} dropped (no candidate), {} dropped (ambiguous)",
         resolved,
         resolved_by_kind_filter,
+        resolved_by_receiver_type,
         dropped_no_enclosing,
         dropped_no_candidate,
         dropped_ambiguous,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -14,7 +14,7 @@ use crate::storage::read;
 use crate::storage::write;
 
 use parser::ParserPool;
-use symbols::{ExtractedImport, ExtractedReference, compute_shape_hash};
+use symbols::{ExtractedImport, ExtractedReference, ReferenceKind, compute_shape_hash};
 
 struct IndexedFile {
     file_id: i64,
@@ -216,19 +216,58 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
 /// using file-level import edges — which target is the most plausible.
 /// Ambiguous names that match many symbols and no import are dropped to
 /// keep the edge count manageable on large codebases.
+/// Candidate entry in the resolver's name index: symbol id, its file id,
+/// and its declared symbol kind. Kind is stored so the resolver can filter
+/// candidates by reference kind — a Call cannot target a variable or
+/// field; a TypeRef cannot target a method.
+type Candidate = (i64, i64, String);
+
+/// Returns true if a symbol of `sym_kind` is a plausible target for a
+/// reference of `ref_kind`. Unknown kinds fall through conservatively
+/// (we would rather keep a questionable edge than drop a valid one when
+/// a language extractor emits a kind we have not mapped here yet).
+fn kind_is_compatible(ref_kind: ReferenceKind, sym_kind: &str) -> bool {
+    match ref_kind {
+        // Plain functions + methods are the obvious case. Classes/structs/
+        // enums/interfaces are included because languages like Dart, Java,
+        // and Kotlin write constructor calls as `Foo(x)` — syntactically a
+        // Call whose target is the type symbol. `type` covers typedefs
+        // used as constructor aliases.
+        ReferenceKind::Call => matches!(
+            sym_kind,
+            "function"
+                | "method"
+                | "class"
+                | "struct"
+                | "enum"
+                | "interface"
+                | "trait"
+                | "type"
+        ),
+        // Type positions resolve only to type-like symbols.
+        ReferenceKind::TypeRef => matches!(
+            sym_kind,
+            "class" | "struct" | "enum" | "interface" | "trait" | "type"
+        ),
+        // Bare identifier use is too underspecified to filter safely.
+        ReferenceKind::Use => true,
+    }
+}
+
 fn resolve_symbol_references(
     conn: &Connection,
     indexed: &[IndexedFile],
     imports_by_file: &HashMap<i64, HashSet<i64>>,
 ) -> Result<()> {
-    // (name -> [(symbol_id, file_id)]) built once for the whole project.
+    // (name -> [(symbol_id, file_id, kind)]) built once for the whole project.
     let all_syms = read::get_all_symbols_with_path(conn)?;
-    let mut name_index: HashMap<String, Vec<(i64, i64)>> = HashMap::with_capacity(all_syms.len());
+    let mut name_index: HashMap<String, Vec<Candidate>> =
+        HashMap::with_capacity(all_syms.len());
     for (sym, _path) in &all_syms {
         name_index
             .entry(sym.name.clone())
             .or_default()
-            .push((sym.id, sym.file_id));
+            .push((sym.id, sym.file_id, sym.kind.clone()));
     }
 
     let mut batch: Vec<(i64, i64, &'static str)> = Vec::new();
@@ -236,6 +275,7 @@ fn resolve_symbol_references(
     let mut dropped_no_enclosing = 0usize;
     let mut dropped_no_candidate = 0usize;
     let mut dropped_ambiguous = 0usize;
+    let mut resolved_by_kind_filter = 0usize;
 
     for entry in indexed {
         let empty_imports = HashSet::new();
@@ -257,27 +297,47 @@ fn resolve_symbol_references(
                 continue;
             };
 
-            let candidates = match name_index.get(&reference.name) {
-                Some(c) if !c.is_empty() => c,
+            let raw_candidates = match name_index.get(&reference.name) {
+                Some(c) if !c.is_empty() => c.as_slice(),
                 _ => {
                     dropped_no_candidate += 1;
                     continue;
                 }
             };
 
+            // Kind filter: restrict candidates to kinds that a reference
+            // of this kind could plausibly resolve to. Keeps an ambiguous
+            // name (e.g. a variable `length` and a method `length`) from
+            // being dropped at P3 when one of the candidates is the only
+            // plausible target given the call-vs-type context.
+            let filtered: Vec<&Candidate> = raw_candidates
+                .iter()
+                .filter(|(_, _, k)| kind_is_compatible(reference.kind, k))
+                .collect();
+            let narrowed_by_kind =
+                !filtered.is_empty() && filtered.len() < raw_candidates.len();
+            // Fall back to the raw list if kind-filtering erased every
+                // option — avoids silently dropping edges when a language
+                // extractor emits a kind this resolver has not mapped.
+            let candidates: Vec<&Candidate> = if filtered.is_empty() {
+                raw_candidates.iter().collect()
+            } else {
+                filtered
+            };
+
             // Priority 1: target lives in the same file as the caller.
             let mut picked: Vec<i64> = candidates
                 .iter()
-                .filter(|(sid, fid)| *fid == entry.file_id && *sid != from_id)
-                .map(|(sid, _)| *sid)
+                .filter(|(sid, fid, _)| *fid == entry.file_id && *sid != from_id)
+                .map(|(sid, _, _)| *sid)
                 .collect();
 
             // Priority 2: target lives in a file this caller imports from.
             if picked.is_empty() {
                 picked = candidates
                     .iter()
-                    .filter(|(_, fid)| imported.contains(fid))
-                    .map(|(sid, _)| *sid)
+                    .filter(|(_, fid, _)| imported.contains(fid))
+                    .map(|(sid, _, _)| *sid)
                     .collect();
             }
 
@@ -294,6 +354,10 @@ fn resolve_symbol_references(
                 }
             }
 
+            if narrowed_by_kind {
+                resolved_by_kind_filter += 1;
+            }
+
             for target in picked {
                 batch.push((from_id, target, reference.kind.as_str()));
                 resolved += 1;
@@ -304,8 +368,9 @@ fn resolve_symbol_references(
     write::insert_symbol_refs(conn, &batch)?;
 
     tracing::info!(
-        "symbol references: {} resolved, {} dropped (no enclosing), {} dropped (no candidate), {} dropped (ambiguous)",
+        "symbol references: {} resolved ({} via kind filter), {} dropped (no enclosing), {} dropped (no candidate), {} dropped (ambiguous)",
         resolved,
+        resolved_by_kind_filter,
         dropped_no_enclosing,
         dropped_no_candidate,
         dropped_ambiguous,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -609,13 +609,20 @@ fn read_go_module(root: &Path) -> Option<String> {
 /// Resolves a Dart `import`/`part` specifier to a file path relative to `root`.
 ///
 /// Handles three specifier shapes:
-///   * `dart:io`, `dart:async`      → SDK, not in the workspace, return empty.
-///   * `package:NAME/a/b.dart`      → look up NAME in the workspace package
-///                                    map and rewrite to `<pkg-dir>/lib/a/b.dart`.
+///   * `dart:io`, `dart:async` — SDK, not in the workspace, return empty.
+///   * `package:NAME/a/b.dart` — look up NAME in the workspace package map
+///     and rewrite to `<pkg-dir>/lib/a/b.dart`.
 ///   * relative (`./x.dart`, `../x.dart`, `x.dart`) — including `part`
-///                                    directives, which always carry a
-///                                    relative URI — fall through to the
-///                                    generic relative resolver.
+///     directives, which always carry a relative URI — fall through to the
+///     generic relative resolver.
+///
+/// **Scope:** workspace-only. Only packages whose `pubspec.yaml` lives inside
+/// `root` are resolvable; path-/git-dependencies outside the workspace and
+/// pub-cache packages are intentionally ignored. We do not consult
+/// `.dart_tool/package_config.json` — it requires `pub get` to be fresh and
+/// would pull cache paths that are irrelevant for symbol indexing. A
+/// `package:` import whose package name is not in the workspace map returns
+/// no edge.
 fn resolve_dart_import(
     rel_path: &str,
     specifier: &str,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -33,6 +33,7 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     let files = walker::walk_source_files(root);
     let pool = ParserPool::new();
     let go_module = read_go_module(root);
+    let dart_packages = read_dart_packages(root);
 
     tracing::info!("found {} source files on disk", files.len());
 
@@ -168,6 +169,7 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
                 root,
                 &known_paths,
                 go_module.as_deref(),
+                Some(&dart_packages),
             );
             for target_rel in &targets {
                 if let Some(&target_id) = path_to_id.get(target_rel.as_str()) {
@@ -319,6 +321,7 @@ fn resolve_targets(
     root: &Path,
     known_files: &HashSet<String>,
     go_module: Option<&str>,
+    dart_packages: Option<&HashMap<String, String>>,
 ) -> Vec<String> {
     match language {
         "rust" => resolve_rust_import(rel_path, specifier, known_files)
@@ -328,6 +331,7 @@ fn resolve_targets(
             .into_iter()
             .collect(),
         "go" => resolve_go_import(specifier, known_files, go_module),
+        "dart" => resolve_dart_import(rel_path, specifier, root, known_files, dart_packages),
         _ => {
             let importing_file = root.join(rel_path);
             resolve_import(&importing_file, specifier, root, known_files)
@@ -600,6 +604,126 @@ fn read_go_module(root: &Path) -> Option<String> {
     })
 }
 
+// --- Dart ---
+
+/// Resolves a Dart `import`/`part` specifier to a file path relative to `root`.
+///
+/// Handles three specifier shapes:
+///   * `dart:io`, `dart:async`      → SDK, not in the workspace, return empty.
+///   * `package:NAME/a/b.dart`      → look up NAME in the workspace package
+///                                    map and rewrite to `<pkg-dir>/lib/a/b.dart`.
+///   * relative (`./x.dart`, `../x.dart`, `x.dart`) — including `part`
+///                                    directives, which always carry a
+///                                    relative URI — fall through to the
+///                                    generic relative resolver.
+fn resolve_dart_import(
+    rel_path: &str,
+    specifier: &str,
+    root: &Path,
+    known_files: &HashSet<String>,
+    dart_packages: Option<&HashMap<String, String>>,
+) -> Vec<String> {
+    if specifier.starts_with("dart:") {
+        return vec![];
+    }
+
+    if let Some(rest) = specifier.strip_prefix("package:") {
+        let packages = match dart_packages {
+            Some(p) => p,
+            None => return vec![],
+        };
+        let (name, tail) = match rest.split_once('/') {
+            Some(parts) => parts,
+            None => return vec![],
+        };
+        let pkg_dir = match packages.get(name) {
+            Some(d) => d,
+            None => return vec![],
+        };
+        let candidate = if pkg_dir.is_empty() {
+            format!("lib/{tail}")
+        } else {
+            format!("{pkg_dir}/lib/{tail}")
+        };
+        let normalized = normalize_path(Path::new(&candidate))
+            .to_string_lossy()
+            .to_string();
+        if known_files.contains(&normalized) {
+            return vec![normalized];
+        }
+        return vec![];
+    }
+
+    let importing_file = root.join(rel_path);
+    resolve_import(&importing_file, specifier, root, known_files)
+        .into_iter()
+        .collect()
+}
+
+/// Walks the workspace for `pubspec.yaml` files and returns a map from each
+/// declared package name to its directory (relative to `root`, forward-slash
+/// form, empty string for a pubspec at the root). Used by
+/// `resolve_dart_import` to translate `package:foo/…` imports to real files.
+fn read_dart_packages(root: &Path) -> HashMap<String, String> {
+    let mut packages = HashMap::new();
+    let walker = ignore::WalkBuilder::new(root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        if path.file_name().and_then(|n| n.to_str()) != Some("pubspec.yaml") {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let Some(name) = parse_pubspec_name(&content) else {
+            continue;
+        };
+
+        let rel_dir = match path.parent().and_then(|p| p.strip_prefix(root).ok()) {
+            Some(p) => p.to_string_lossy().replace('\\', "/"),
+            None => continue,
+        };
+
+        packages.insert(name, rel_dir);
+    }
+
+    packages
+}
+
+/// Extracts the top-level `name:` field from a `pubspec.yaml` body. Only
+/// unindented `name:` keys count — an indented `name:` under some other
+/// mapping must not hijack the package identity.
+fn parse_pubspec_name(pubspec: &str) -> Option<String> {
+    for raw in pubspec.lines() {
+        let line = raw.split('#').next().unwrap_or("");
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.starts_with(|c: char| c.is_whitespace()) {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("name:") {
+            let value = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
 // --- Helpers ---
 
 fn normalize_path(path: &Path) -> std::path::PathBuf {
@@ -650,6 +774,7 @@ pub fn incremental_index(
 
     let pool = ParserPool::new();
     let go_module = read_go_module(root);
+    let dart_packages = read_dart_packages(root);
 
     let tx = conn.unchecked_transaction()?;
 
@@ -767,6 +892,7 @@ pub fn incremental_index(
                 root,
                 &known_paths,
                 go_module.as_deref(),
+                Some(&dart_packages),
             );
             for target_rel in &targets {
                 if let Some(&target_id) = path_to_id.get(target_rel.as_str()) {
@@ -1054,6 +1180,199 @@ mod tests {
         let known = HashSet::new();
         let result = resolve_go_import("pkg/utils", &known, None);
         assert!(result.is_empty());
+    }
+
+    // --- Dart resolver ---
+
+    #[test]
+    fn test_parse_pubspec_name_simple() {
+        let yaml = "name: arrow_core\nversion: 0.1.0\n";
+        assert_eq!(parse_pubspec_name(yaml), Some("arrow_core".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_quoted() {
+        assert_eq!(
+            parse_pubspec_name("name: 'arrow_core'\n"),
+            Some("arrow_core".to_string())
+        );
+        assert_eq!(
+            parse_pubspec_name("name: \"arrow_core\"\n"),
+            Some("arrow_core".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_ignores_indented() {
+        let yaml = "dev_dependencies:\n  pkg:\n    name: nested\n";
+        assert_eq!(parse_pubspec_name(yaml), None);
+    }
+
+    #[test]
+    fn test_parse_pubspec_name_ignores_comments() {
+        let yaml = "# name: wrong\nname: right\n";
+        assert_eq!(parse_pubspec_name(yaml), Some("right".to_string()));
+    }
+
+    #[test]
+    fn test_read_dart_packages_monorepo() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("options")).unwrap();
+        fs::create_dir_all(root.join("core")).unwrap();
+        fs::write(root.join("options/pubspec.yaml"), "name: arrow_options\n").unwrap();
+        fs::write(root.join("core/pubspec.yaml"), "name: arrow_core\n").unwrap();
+
+        let packages = read_dart_packages(root);
+        assert_eq!(packages.get("arrow_options"), Some(&"options".to_string()));
+        assert_eq!(packages.get("arrow_core"), Some(&"core".to_string()));
+    }
+
+    #[test]
+    fn test_read_dart_packages_root_pubspec() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(root.join("pubspec.yaml"), "name: arrow\n").unwrap();
+
+        let packages = read_dart_packages(root);
+        assert_eq!(packages.get("arrow"), Some(&"".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_dart_import_package() {
+        let mut pkgs = HashMap::new();
+        pkgs.insert("arrow_options".to_string(), "options".to_string());
+        let mut known = HashSet::new();
+        known.insert("options/lib/src/body.dart".to_string());
+        known.insert("options/lib/arrow_options.dart".to_string());
+
+        let result = resolve_dart_import(
+            "core/lib/src/chart.dart",
+            "package:arrow_options/src/body.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["options/lib/src/body.dart".to_string()]);
+
+        let result = resolve_dart_import(
+            "core/lib/src/chart.dart",
+            "package:arrow_options/arrow_options.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["options/lib/arrow_options.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_dart_import_package_at_root() {
+        let mut pkgs = HashMap::new();
+        pkgs.insert("arrow".to_string(), "".to_string());
+        let mut known = HashSet::new();
+        known.insert("lib/src/chart.dart".to_string());
+
+        let result = resolve_dart_import(
+            "lib/main.dart",
+            "package:arrow/src/chart.dart",
+            Path::new("/"),
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["lib/src/chart.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_resolve_dart_import_sdk_is_empty() {
+        let pkgs = HashMap::new();
+        let known = HashSet::new();
+        assert!(
+            resolve_dart_import(
+                "lib/main.dart",
+                "dart:async",
+                Path::new("/"),
+                &known,
+                Some(&pkgs)
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_resolve_dart_import_unknown_package_is_empty() {
+        let pkgs = HashMap::new();
+        let known = HashSet::new();
+        assert!(
+            resolve_dart_import(
+                "lib/main.dart",
+                "package:flutter/material.dart",
+                Path::new("/"),
+                &known,
+                Some(&pkgs)
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_resolve_dart_import_relative() {
+        let pkgs = HashMap::new();
+        let mut known = HashSet::new();
+        known.insert("lib/src/helper.dart".to_string());
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let result = resolve_dart_import(
+            "lib/src/main.dart",
+            "./helper.dart",
+            root,
+            &known,
+            Some(&pkgs),
+        );
+        assert_eq!(result, vec!["lib/src/helper.dart".to_string()]);
+    }
+
+    #[test]
+    fn test_full_index_resolves_dart_package_imports() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join("options/lib/src")).unwrap();
+        fs::create_dir_all(root.join("core/lib/src")).unwrap();
+        fs::write(root.join("options/pubspec.yaml"), "name: arrow_options\n").unwrap();
+        fs::write(root.join("core/pubspec.yaml"), "name: arrow_core\n").unwrap();
+        fs::write(
+            root.join("options/lib/src/body.dart"),
+            "enum Body { sun, moon }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("core/lib/src/chart.dart"),
+            "import 'package:arrow_options/src/body.dart';\n\
+             class Chart { Body? sun; }\n",
+        )
+        .unwrap();
+
+        let conn = storage::open_in_memory().unwrap();
+        full_index(&conn, root, true).unwrap();
+
+        let chart_id = read::get_file_by_path(&conn, "core/lib/src/chart.dart")
+            .unwrap()
+            .unwrap()
+            .id;
+        let body_id = read::get_file_by_path(&conn, "options/lib/src/body.dart")
+            .unwrap()
+            .unwrap()
+            .id;
+
+        let edges = read::get_all_edges(&conn).unwrap();
+        let has_edge = edges
+            .iter()
+            .any(|e| e.0 == chart_id && e.1 == body_id);
+        assert!(
+            has_edge,
+            "expected chart.dart → body.dart import edge, got edges {edges:?}"
+        );
     }
 
     // --- Integration tests ---

--- a/src/index/symbols.rs
+++ b/src/index/symbols.rs
@@ -160,6 +160,12 @@ pub struct ExtractedReference {
     /// via the insert-order id map that `insert_symbols` already produces.
     pub from_symbol_idx: Option<usize>,
     pub kind: ReferenceKind,
+    /// Syntactic type annotation of a call's receiver, if the extractor
+    /// resolved it from a typed local, parameter, field, or getter return.
+    /// `Some("Foo")` means the call was `receiver.name(...)` where `receiver`
+    /// was declared as `Foo`. The resolver uses this to narrow candidates to
+    /// methods whose parent class matches.
+    pub receiver_type_hint: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2623,7 +2623,7 @@ impl QartezServer {
 
     #[tool(
         name = "qartez_project",
-        description = "Run project commands (test, build, lint, typecheck) with auto-detected toolchain (Cargo, npm/bun/yarn, Go, Python, Make). Use action='info' to see detected commands. Use filter for targeted runs (e.g., test name).",
+        description = "Run project commands (test, build, lint, typecheck) with auto-detected toolchain (Cargo, npm/bun/yarn/pnpm, Go, Python, Dart/Flutter, Maven, Gradle, sbt, Ruby, Make). Use action='info' to see detected commands. Use filter for targeted runs (e.g., test name).",
         annotations(
             title = "Run Project Command",
             read_only_hint = false,
@@ -2641,7 +2641,7 @@ impl QartezServer {
 
         if action == ProjectAction::Info {
             if all_toolchains.is_empty() {
-                return Err("No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, Gemfile, Makefile".to_string());
+                return Err("No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, pubspec.yaml, Gemfile, Makefile, pom.xml, build.gradle(.kts), build.sbt".to_string());
             }
             let mut out = String::new();
             for (i, tc) in all_toolchains.iter().enumerate() {
@@ -2669,7 +2669,7 @@ impl QartezServer {
         }
 
         let tc = all_toolchains.into_iter().next().ok_or_else(|| {
-            "No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, Gemfile, Makefile".to_string()
+            "No recognized toolchain found. Looked for: Cargo.toml, package.json, go.mod, pyproject.toml, setup.py, pubspec.yaml, Gemfile, Makefile, pom.xml, build.gradle(.kts), build.sbt".to_string()
         })?;
 
         if action == ProjectAction::Run {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -959,6 +959,7 @@ fn compute_cochange_pairs(
 fn is_test_path(path: &str) -> bool {
     // Directory-based patterns (all languages)
     if path.starts_with("tests/")
+        || path.starts_with("test/")
         || path.starts_with("benches/")
         || path.starts_with("__tests__/")
         || path.starts_with("spec/")
@@ -966,6 +967,7 @@ fn is_test_path(path: &str) -> bool {
         return true;
     }
     if path.contains("/tests/")
+        || path.contains("/test/")
         || path.contains("/benches/")
         || path.contains("/__tests__/")
         || path.contains("/spec/")
@@ -982,6 +984,10 @@ fn is_test_path(path: &str) -> bool {
         }
         // Go: _test.go
         if name.ends_with("_test.go") {
+            return true;
+        }
+        // Dart: _test.dart
+        if name.ends_with("_test.dart") {
             return true;
         }
         // TypeScript/JavaScript: .test.ts, .spec.ts, .test.tsx, .spec.tsx,
@@ -3487,7 +3493,7 @@ impl QartezServer {
         };
 
         let mut out = format!(
-            "files={} (src={}/test={}) loc={}/{} syms={} edges={} indexed={}/{}\n",
+            "files={} (src={}/test={}) loc={}/{} syms={} edges={} with_symbols={}/{}\n",
             file_count,
             src_files.len(),
             test_files.len(),

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -130,6 +130,35 @@ pub fn detect_all_toolchains(project_root: &Path) -> Vec<DetectedToolchain> {
         });
     }
 
+    if project_root.join("pubspec.yaml").exists() {
+        let pubspec = std::fs::read_to_string(project_root.join("pubspec.yaml")).unwrap_or_default();
+        let is_flutter = pubspec_uses_flutter(&pubspec);
+        let has_build_runner = pubspec.contains("build_runner:");
+        let driver = if is_flutter { "flutter" } else { "dart" };
+
+        let build_cmd = if has_build_runner {
+            vec![
+                "dart".into(),
+                "run".into(),
+                "build_runner".into(),
+                "build".into(),
+                "--delete-conflicting-outputs".into(),
+            ]
+        } else {
+            vec![driver.into(), "pub".into(), "get".into()]
+        };
+
+        toolchains.push(DetectedToolchain {
+            name: if is_flutter { "flutter".into() } else { "dart".into() },
+            build_tool: driver.into(),
+            test_cmd: vec![driver.into(), "test".into()],
+            build_cmd,
+            lint_cmd: Some(vec![driver.into(), "analyze".into()]),
+            // `dart analyze` covers static type checking — no separate typechecker.
+            typecheck_cmd: Some(vec![driver.into(), "analyze".into()]),
+        });
+    }
+
     if project_root.join("Makefile").exists() {
         toolchains.push(DetectedToolchain {
             name: "make".to_string(),
@@ -157,6 +186,43 @@ pub fn binary_available(name: &str) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+fn pubspec_uses_flutter(pubspec: &str) -> bool {
+    // Flutter projects declare `flutter:` under `dependencies:` with `sdk: flutter`,
+    // or include a top-level `flutter:` configuration block. Either signal is enough.
+    let mut in_deps = false;
+    let mut saw_flutter_key = false;
+    for raw in pubspec.lines() {
+        let line = raw.split('#').next().unwrap_or("");
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let indent = trimmed.len() - trimmed.trim_start().len();
+        let body = trimmed.trim_start();
+
+        if indent == 0 {
+            in_deps = matches!(body, "dependencies:" | "dev_dependencies:");
+            if body == "flutter:" {
+                return true;
+            }
+            saw_flutter_key = false;
+            continue;
+        }
+
+        if in_deps && indent == 2 && body == "flutter:" {
+            saw_flutter_key = true;
+            continue;
+        }
+        if saw_flutter_key && indent >= 4 && body.starts_with("sdk:") && body.contains("flutter") {
+            return true;
+        }
+        if indent <= 2 {
+            saw_flutter_key = false;
+        }
+    }
+    false
 }
 
 fn detect_node_package_manager(project_root: &Path) -> String {
@@ -425,6 +491,77 @@ mod tests {
 
         let tc = detect_toolchain(dir.path()).unwrap();
         assert_eq!(tc.name, "scala");
+    }
+
+    #[test]
+    fn test_detect_dart_library() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_lib\nenvironment:\n  sdk: '>=3.0.0 <4.0.0'\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart");
+        assert_eq!(tc.build_tool, "dart");
+        assert_eq!(tc.test_cmd, vec!["dart", "test"]);
+        assert_eq!(tc.build_cmd, vec!["dart", "pub", "get"]);
+        assert_eq!(tc.lint_cmd.unwrap(), vec!["dart", "analyze"]);
+        assert_eq!(tc.typecheck_cmd.unwrap(), vec!["dart", "analyze"]);
+    }
+
+    #[test]
+    fn test_detect_dart_with_build_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_lib\ndev_dependencies:\n  build_runner: ^2.4.0\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart");
+        assert_eq!(
+            tc.build_cmd,
+            vec![
+                "dart",
+                "run",
+                "build_runner",
+                "build",
+                "--delete-conflicting-outputs",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_detect_flutter_via_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_app\ndependencies:\n  flutter:\n    sdk: flutter\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "flutter");
+        assert_eq!(tc.build_tool, "flutter");
+        assert_eq!(tc.test_cmd, vec!["flutter", "test"]);
+        assert_eq!(tc.build_cmd, vec!["flutter", "pub", "get"]);
+        assert_eq!(tc.lint_cmd.unwrap(), vec!["flutter", "analyze"]);
+    }
+
+    #[test]
+    fn test_detect_flutter_via_top_level_block() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: my_app\nflutter:\n  uses-material-design: true\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "flutter");
     }
 
     #[test]

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -189,9 +189,12 @@ pub fn binary_available(name: &str) -> bool {
 }
 
 fn pubspec_uses_flutter(pubspec: &str) -> bool {
-    // Flutter projects declare `flutter:` under `dependencies:` with `sdk: flutter`,
-    // or include a top-level `flutter:` configuration block. Either signal is enough.
-    let mut in_deps = false;
+    // Flutter projects declare `flutter:` under *runtime* `dependencies:` with
+    // `sdk: flutter`, or include a top-level `flutter:` configuration block.
+    // `dev_dependencies:` is explicitly excluded — pure-Dart packages commonly
+    // test with `flutter_test`, and we must not flip those to the Flutter
+    // toolchain.
+    let mut in_runtime_deps = false;
     let mut saw_flutter_key = false;
     for raw in pubspec.lines() {
         let line = raw.split('#').next().unwrap_or("");
@@ -203,7 +206,7 @@ fn pubspec_uses_flutter(pubspec: &str) -> bool {
         let body = trimmed.trim_start();
 
         if indent == 0 {
-            in_deps = matches!(body, "dependencies:" | "dev_dependencies:");
+            in_runtime_deps = body == "dependencies:";
             if body == "flutter:" {
                 return true;
             }
@@ -211,7 +214,7 @@ fn pubspec_uses_flutter(pubspec: &str) -> bool {
             continue;
         }
 
-        if in_deps && indent == 2 && body == "flutter:" {
+        if in_runtime_deps && indent == 2 && body == "flutter:" {
             saw_flutter_key = true;
             continue;
         }
@@ -549,6 +552,28 @@ mod tests {
         assert_eq!(tc.test_cmd, vec!["flutter", "test"]);
         assert_eq!(tc.build_cmd, vec!["flutter", "pub", "get"]);
         assert_eq!(tc.lint_cmd.unwrap(), vec!["flutter", "analyze"]);
+    }
+
+    #[test]
+    fn test_flutter_sdk_under_dev_dependencies_stays_dart() {
+        // Pure-Dart libraries commonly depend on `flutter_test` for their
+        // widget tests, which pulls `flutter: sdk: flutter` into
+        // `dev_dependencies`. The toolchain must stay `dart`, not flip to
+        // `flutter`.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("pubspec.yaml"),
+            "name: pure_dart_lib\n\
+             dev_dependencies:\n\
+             \u{0020}\u{0020}flutter:\n\
+             \u{0020}\u{0020}\u{0020}\u{0020}sdk: flutter\n\
+             \u{0020}\u{0020}flutter_test:\n\
+             \u{0020}\u{0020}\u{0020}\u{0020}sdk: flutter\n",
+        )
+        .unwrap();
+
+        let tc = detect_toolchain(dir.path()).unwrap();
+        assert_eq!(tc.name, "dart", "dev-only flutter must stay dart toolchain");
     }
 
     #[test]

--- a/tests/business_logic.rs
+++ b/tests/business_logic.rs
@@ -1777,6 +1777,11 @@ fn test_analyze_cochanges_file_count_filtering() {
     make_commit(&repo, &["c.rs"], "one file");
 
     let conn = setup();
+    // Pre-register files as `full_index` would: co-change no longer creates
+    // phantom rows, so paths must already exist in `files` to participate.
+    write::get_or_create_file(&conn, "a.rs").unwrap();
+    write::get_or_create_file(&conn, "b.rs").unwrap();
+    write::get_or_create_file(&conn, "c.rs").unwrap();
     let config = CoChangeConfig {
         commit_limit: 100,
         min_files: 2,
@@ -1900,6 +1905,10 @@ fn test_analyze_cochanges_subdirectory_dotfile_not_filtered() {
     make_commit(&repo, &[".github/ci.yml", "src/main.rs"], "github ci");
 
     let conn = setup();
+    // Pre-register files as `full_index` would — co-change now skips paths
+    // that aren't in the files table.
+    write::get_or_create_file(&conn, ".github/ci.yml").unwrap();
+    write::get_or_create_file(&conn, "src/main.rs").unwrap();
     analyze_cochanges(&conn, dir.path(), &CoChangeConfig::default()).unwrap();
 
     // .github/ci.yml should NOT be filtered because only the filename


### PR DESCRIPTION
Split of #3, rebased on current `main` (v0.2.0). This is **PR B** — cross-cutting resolver and co-change changes.

**Ordering note:** this branch is stacked on [PR A](https://github.com/kuberstar/qartez-mcp/pull/5), not `main`. I couldn't cleanly separate the `receiver_type_hint` field plumbing from the Dart receiver-type heuristic that populates it — they're one commit that touches both the ExtractedReference struct and the Dart extractor. Splitting that would have required two rebase passes and is fiddly to review. Merging PR A first then this one gives you clean deltas. Happy to do further surgery if you'd rather see the field plumbing alone here.

## What's in this PR

### 1. Co-change phantom-files fix
`analyze_cochanges` was calling `get_or_create_file` on every path seen in git history, which inserted zero-size/zero-mtime rows for files that had been deleted or renamed. Those rows then showed up in `qartez_stats` as "unindexed", confused the guard thresholds, and survived `--reindex`. Now co-change only records pairs where both paths exist in the `files` table (i.e. were inserted by `full_index` from disk); historical-only paths are skipped and counted in the log line.

The co-change test that previously asserted phantom creation (`test_unindexed_files_are_auto_created`) is rewritten as `test_unregistered_paths_are_skipped` to assert the new, correct behavior.

### 2. Co-change filter-test pre-registration
`test_analyze_cochanges_file_count_filtering` and `test_analyze_cochanges_subdirectory_dotfile_not_filtered` pre-existed the phantom-files fix and relied on the old auto-create behavior. They now call `get_or_create_file` up front to mirror what `full_index` does in production.

### 3. Resolver kind-filter
`resolve_symbol_references` now restricts the candidate pool by reference kind before running the same-file / imported-file / global-unique priorities:
- `Call` → function, method, class, struct, enum, interface, trait, type (constructors look like Call in Dart/Java/Kotlin)
- `TypeRef` → class, struct, enum, interface, trait, type
- `Use` → unrestricted

Falls back to the raw pool when filtering erases every candidate (safety net for extractors emitting unmapped kinds). Measured on arrow (101 Dart files): **864 → 927 resolved (+63), 504 → 419 ambiguous (-85), 129 resolved by kind filter.**

### 4. Receiver-type heuristic for Dart method calls
Adds `ExtractedReference.receiver_type_hint`, populated by the Dart extractor from typed locals, parameters, and class fields. Resolver runs this as Priority 1 before the same-file/import/global cascade: when a call carries a hint and exactly one candidate's `parent_id` names a class of that type, it resolves uniquely.

On arrow: **+18 refs resolved via receiver type.** Most rescues were same-file multi-hits pruned to the correct target, not previously-ambiguous saves.

The field is added to `ExtractedReference` and `receiver_type_hint: None` defaults are wired through every other language extractor, so the field is available project-wide even though only Dart populates it today.

## Test plan

- [x] `cargo test --release` — all pass on the stacked base
- [x] `cargo clippy --release --all-targets` — no new warnings
- [x] Arrow measurement reproduced: resolver counters show 927 resolved / 129 via kind filter / +18 via receiver type