### PR TITLE
fix(startup): background indexing so MCP tools load immediately (PR C of 3)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,23 +30,26 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Database ready at {}", config.db_path.display());
 
     if config.has_project {
-        for root in &config.project_roots {
-            tracing::info!("Indexing root: {}", root.display());
-            index::full_index(&conn, root, config.reindex)?;
-        }
-        graph::pagerank::compute_pagerank(&conn, &Default::default())?;
-        graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())?;
-        git::cochange::analyze_cochanges(
-            &conn,
-            &config.primary_root,
-            &git::cochange::CoChangeConfig {
-                commit_limit: config.git_depth,
-                ..Default::default()
-            },
-        )?;
-        tracing::info!("Index complete for {} root(s)", config.project_roots.len());
-
         if let Some(wiki_path) = cli.wiki.as_ref() {
+            // Wiki generation depends on a fresh index + pagerank + co-change,
+            // and the CLI caller is explicitly waiting for the output file.
+            // Keep this path synchronous.
+            for root in &config.project_roots {
+                tracing::info!("Indexing root: {}", root.display());
+                index::full_index(&conn, root, config.reindex)?;
+            }
+            graph::pagerank::compute_pagerank(&conn, &Default::default())?;
+            graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())?;
+            git::cochange::analyze_cochanges(
+                &conn,
+                &config.primary_root,
+                &git::cochange::CoChangeConfig {
+                    commit_limit: config.git_depth,
+                    ..Default::default()
+                },
+            )?;
+            tracing::info!("Index complete for {} root(s)", config.project_roots.len());
+
             let project_name = config
                 .primary_root
                 .canonicalize()
@@ -80,6 +83,58 @@ async fn main() -> anyhow::Result<()> {
                 abs.display(),
                 modularity.unwrap_or(0.0),
             );
+        } else {
+            // MCP-server path: spawn indexing on a dedicated connection so
+            // `server.serve()` below can answer `initialize`/`list_tools`
+            // immediately. Tool calls issued before the background task
+            // finishes see whatever the DB carried over from the previous
+            // run (empty on first-ever start).
+            let db_path = config.db_path.clone();
+            let project_roots = config.project_roots.clone();
+            let primary_root = config.primary_root.clone();
+            let reindex = config.reindex;
+            let git_depth = config.git_depth;
+            tokio::task::spawn_blocking(move || {
+                let conn = match storage::open_db(&db_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::error!("background indexer: open_db failed: {e}");
+                        return;
+                    }
+                };
+                for root in &project_roots {
+                    tracing::info!("Indexing root: {}", root.display());
+                    if let Err(e) = index::full_index(&conn, root, reindex) {
+                        tracing::error!(
+                            "background indexer: full_index failed for {}: {e}",
+                            root.display()
+                        );
+                        return;
+                    }
+                }
+                if let Err(e) = graph::pagerank::compute_pagerank(&conn, &Default::default()) {
+                    tracing::error!("background indexer: pagerank failed: {e}");
+                }
+                if let Err(e) =
+                    graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())
+                {
+                    tracing::error!("background indexer: symbol_pagerank failed: {e}");
+                }
+                if let Err(e) = git::cochange::analyze_cochanges(
+                    &conn,
+                    &primary_root,
+                    &git::cochange::CoChangeConfig {
+                        commit_limit: git_depth,
+                        ..Default::default()
+                    },
+                ) {
+                    tracing::error!("background indexer: cochange failed: {e}");
+                }
+                tracing::info!(
+                    "Background index complete for {} root(s)",
+                    project_roots.len()
+                );
+            });
         }
     } else {
         tracing::info!("No project detected, starting MCP server with empty index");


### PR DESCRIPTION
Separate from the Dart split ([PR A](https://github.com/kuberstar/qartez-mcp/pull/5), [PR B](https://github.com/kuberstar/qartez-mcp/pull/6)) — a small startup fix I've been running locally. Opening it as its own PR so you can decide on this piece independently.

## What it does

Moves `full_index` + pagerank + co-change off the startup path in the MCP-server mode. They now run on a dedicated sqlite connection via `tokio::task::spawn_blocking`, letting `server.serve()` answer `initialize` and `list_tools` right away instead of blocking 10–30s on a warm index (or longer on `--reindex`).

Tool calls issued before the background task finishes see whatever state the DB carried over from the previous run (empty on first-ever start). WAL mode keeps concurrent reads non-blocking; writers serialize via the 5s `busy_timeout` already set in `open_db`.

The `--wiki` path stays synchronous because its CLI caller is waiting for the output file.

## Why

I hit this running qartez-mcp under Claude Code: Claude Code's MCP client has a short handshake timeout, and on a warm but non-trivial project the synchronous startup (index + pagerank + cochange) would occasionally push past it, causing tool discovery to fail and the whole server to be marked unavailable. Backgrounding the heavy work lets the handshake complete immediately; the first few tool calls may race the indexer but that's a much better failure mode than \"no tools\".

## Caveats

This fixes the symptom I had, but I'm not sure it's the right general shape:

- **First-ever start races** are non-obvious: calls that arrive before the background task writes any symbols see an empty DB and return \"nothing found\" rather than blocking. That's surprising for a caller who expects startup to mean \"ready\".
- **Sidesteps vs. fixes the latency.** If the real goal is a snappy first-tool-call, there are other approaches — a cheap \"is-the-index-hot-enough\" probe, a synchronous-but-bounded warmup, per-tool lazy indexing, a separate `prepare` CLI subcommand that callers invoke explicitly, etc.
- **Error propagation.** A background-task failure currently only logs; the server stays up with a half-indexed DB. Acceptable for my use case but arguably the wrong default.

Totally open to a different shape if you'd prefer one. Flagging all of this so you can push back before merging.

## Test plan

- [x] `cargo test --release` — all pass on current `main` base
- [x] Smoke: started under Claude Code against the arrow repo — initialize + list_tools return within ~100ms; `qartez_map` called immediately returns partial results, then full results after the background task finishes (~8s later)