### PR TITLE
fix: prevent unbounded database growth on large codebases

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -29,6 +29,16 @@ struct IndexedFile {
     references: Vec<ExtractedReference>,
 }
 
+/// Maximum file size to index. Files larger than this are skipped — they are
+/// typically generated code and inflate the index without meaningful signal.
+/// Override via the `QARTEZ_MAX_FILE_BYTES` environment variable.
+fn max_file_bytes() -> u64 {
+    std::env::var("QARTEZ_MAX_FILE_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1_000_000) // 1 MB default
+}
+
 pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     let files = walker::walk_source_files(root);
     let pool = ParserPool::new();
@@ -58,6 +68,15 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
         };
         let mtime_ns = file_mtime_ns(&metadata);
         let size_bytes = metadata.len() as i64;
+
+        if metadata.len() > max_file_bytes() {
+            tracing::debug!(
+                "skipping oversized file {} ({} bytes)",
+                file_path.display(),
+                metadata.len()
+            );
+            continue;
+        }
 
         if !force
             && let Some(existing) = read::get_file_by_path(&tx, &rel_path)?
@@ -198,6 +217,13 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     write::set_meta(&tx, "last_index", &timestamp)?;
 
     tx.commit()?;
+
+    // Checkpoint the WAL so it doesn't grow unboundedly across indexing runs.
+    // Failure is non-fatal — the next run or SQLite's auto-checkpoint will
+    // eventually flush it.
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        tracing::debug!("WAL checkpoint after full_index failed (non-fatal): {e}");
+    }
 
     tracing::info!("indexing complete: {updated} updated, {skipped} skipped, {deleted} deleted");
     Ok(())
@@ -686,6 +712,15 @@ pub fn incremental_index(
         let mtime_ns = file_mtime_ns(&metadata);
         let size_bytes = metadata.len() as i64;
 
+        if metadata.len() > max_file_bytes() {
+            tracing::debug!(
+                "incremental: skipping oversized file {} ({} bytes)",
+                file_path.display(),
+                metadata.len()
+            );
+            continue;
+        }
+
         let source = match std::fs::read(file_path) {
             Ok(s) => s,
             Err(e) => {
@@ -785,9 +820,17 @@ pub fn incremental_index(
 
     resolve_symbol_references(&tx, &indexed, &imports_by_file)?;
 
-    // --- Phase 4: rebuild global derived tables ---
-    write::sync_fts(&tx)?;
-    write::rebuild_symbol_bodies(&tx, root)?;
+    // --- Phase 4: update derived tables ---
+    // Update FTS and body index only for the files that actually changed.
+    // This avoids the O(whole-codebase) full-table DELETE+re-insert that
+    // sync_fts / rebuild_symbol_bodies would trigger on every file-save
+    // event — the primary cause of unbounded WAL growth on large codebases.
+    // clear_file_content (called above per file) already removed the old
+    // FTS rows, so here we only need to insert the new ones.
+    for entry in &indexed {
+        write::insert_fts_for_file(&tx, entry.file_id)?;
+        write::rebuild_symbol_bodies_for_file(&tx, root, entry.file_id, &entry.rel_path)?;
+    }
     write::populate_unused_exports(&tx)?;
 
     let timestamp = std::time::SystemTime::now()
@@ -798,6 +841,12 @@ pub fn incremental_index(
     write::set_meta(&tx, "last_index", &timestamp)?;
 
     tx.commit()?;
+
+    // Checkpoint the WAL after each incremental index to prevent unbounded
+    // growth on large codebases with an active file watcher.
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        tracing::debug!("WAL checkpoint after incremental_index failed (non-fatal): {e}");
+    }
 
     tracing::info!(
         "incremental index: {updated} updated, {removed} removed ({} changed, {} deleted input)",

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,29 @@ use crate::error::Result;
 pub fn open_db(db_path: &Path) -> Result<Connection> {
     let conn = Connection::open(db_path)?;
 
+    // Enable incremental auto-vacuum for new databases so freed pages (e.g.
+    // from FTS table rebuilds during indexing) are reclaimed on disk rather
+    // than accumulating indefinitely. This must be set before any tables are
+    // created; for existing databases without auto_vacuum the change has no
+    // effect without a full VACUUM, which we skip here to avoid a long
+    // startup stall — WAL checkpointing after indexing is the primary
+    // mitigation for those.
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |r| r.get(0))
+        .unwrap_or(0);
+    if av == 0 {
+        let table_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if table_count == 0 {
+            conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")?;
+        }
+    }
+
     conn.execute_batch(
         "PRAGMA journal_mode = WAL;
          PRAGMA foreign_keys = ON;

--- a/src/storage/write.rs
+++ b/src/storage/write.rs
@@ -6,6 +6,10 @@ use crate::error::Result;
 use crate::storage::models::SymbolInsert;
 use crate::storage::read::get_file_by_path;
 
+/// Maximum lines stored per symbol body in `symbols_body_fts`. Caps FTS
+/// storage at a bounded size — very large functions are truncated.
+const MAX_BODY_LINES: usize = 500;
+
 pub fn upsert_file(
     conn: &Connection,
     path: &str,
@@ -247,13 +251,72 @@ pub fn rebuild_symbol_bodies(conn: &Connection, project_root: &std::path::Path) 
         let lines: Vec<&str> = text.lines().collect();
         for (id, line_start, line_end) in syms {
             let start = (line_start as usize).saturating_sub(1);
-            let end = (line_end as usize).min(lines.len());
+            let end = (line_end as usize)
+                .min(lines.len())
+                .min(start + MAX_BODY_LINES);
             if start >= lines.len() || start >= end {
                 continue;
             }
             let body = lines[start..end].join("\n");
             insert.execute(rusqlite::params![id, body])?;
         }
+    }
+    Ok(())
+}
+
+/// Insert `symbols_fts` entries for all symbols belonging to `file_id`.
+/// Called after `insert_symbols` during an incremental re-index so that only
+/// the affected file's entries are (re-)written rather than the whole table.
+/// `clear_file_content` must have already removed the old FTS rows for this
+/// file before this function is called.
+pub fn insert_fts_for_file(conn: &Connection, file_id: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO symbols_fts (rowid, name, kind, file_path)
+         SELECT s.id, s.name, s.kind, f.path
+         FROM symbols s
+         JOIN files f ON s.file_id = f.id
+         WHERE s.file_id = ?1",
+        [file_id],
+    )?;
+    Ok(())
+}
+
+/// Insert `symbols_body_fts` entries for the symbols in a single file.
+/// Called during incremental re-indexing instead of `rebuild_symbol_bodies`
+/// (which rebuilds every file) to avoid unbounded WAL growth on large
+/// codebases. `clear_file_content` must have already removed the old body
+/// FTS rows for this file before this function is called.
+pub fn rebuild_symbol_bodies_for_file(
+    conn: &Connection,
+    project_root: &Path,
+    file_id: i64,
+    rel_path: &str,
+) -> Result<()> {
+    let abs = project_root.join(rel_path);
+    let Ok(text) = std::fs::read_to_string(&abs) else {
+        return Ok(());
+    };
+    let lines: Vec<&str> = text.lines().collect();
+
+    let mut select =
+        conn.prepare("SELECT id, line_start, line_end FROM symbols WHERE file_id = ?1")?;
+    let syms: Vec<(i64, u32, u32)> = select
+        .query_map([file_id], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(select);
+
+    let mut insert =
+        conn.prepare("INSERT INTO symbols_body_fts (rowid, body) VALUES (?1, ?2)")?;
+    for (id, line_start, line_end) in syms {
+        let start = (line_start as usize).saturating_sub(1);
+        let end = (line_end as usize)
+            .min(lines.len())
+            .min(start + MAX_BODY_LINES);
+        if start >= lines.len() || start >= end {
+            continue;
+        }
+        let body = lines[start..end].join("\n");
+        insert.execute(rusqlite::params![id, body])?;
     }
     Ok(())
 }


### PR DESCRIPTION
Four changes address the DB size explosion seen when indexing large monorepos (specifically our internal monorepo) via the file watcher:

1. Incremental FTS updates in `incremental_index` Previously `sync_fts` and `rebuild_symbol_bodies` did a full DELETE+re-insert of every symbol across the whole codebase on every file-save event. For a large repo this pumps hundreds of MB into the WAL per save. Now only the changed files' FTS/body rows are updated (new `insert_fts_for_file` / `rebuild_symbol_bodies_for_file`).

2. WAL checkpoint after every index run `PRAGMA wal_checkpoint(TRUNCATE)` is called after both `full_index` and `incremental_index` so the WAL is folded back into the main DB file and truncated rather than growing without bound.

3. Symbol body size cap (`MAX_BODY_LINES = 500`) Limits the text stored per symbol in `symbols_body_fts` to 500 lines, bounding FTS storage to roughly 1–2× the codebase size rather than allowing single enormous functions to dominate.

4. Per-file size limit in indexing (`QARTEZ_MAX_FILE_BYTES`, default 1 MB) Files larger than the limit are skipped during full and incremental indexing. Generated files and binary-adjacent blobs common in Java monorepos are excluded without affecting normal source files.

5. Incremental auto-vacuum for new databases New `.qartez/index.db` files are created with `auto_vacuum = INCREMENTAL` so freed pages (from FTS rebuilds and stale file deletion) are reclaimed from disk over time without requiring a manual VACUUM.