### PR TITLE
fix: prevent unbounded database growth on large codebases, answer immediately and defer index creation concurrently

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -29,6 +29,16 @@ struct IndexedFile {
     references: Vec<ExtractedReference>,
 }
 
+/// Maximum file size to index. Files larger than this are skipped — they are
+/// typically generated code and inflate the index without meaningful signal.
+/// Override via the `QARTEZ_MAX_FILE_BYTES` environment variable.
+fn max_file_bytes() -> u64 {
+    std::env::var("QARTEZ_MAX_FILE_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1_000_000) // 1 MB default
+}
+
 pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     let files = walker::walk_source_files(root);
     let pool = ParserPool::new();
@@ -58,6 +68,15 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
         };
         let mtime_ns = file_mtime_ns(&metadata);
         let size_bytes = metadata.len() as i64;
+
+        if metadata.len() > max_file_bytes() {
+            tracing::debug!(
+                "skipping oversized file {} ({} bytes)",
+                file_path.display(),
+                metadata.len()
+            );
+            continue;
+        }
 
         if !force
             && let Some(existing) = read::get_file_by_path(&tx, &rel_path)?
@@ -198,6 +217,13 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
     write::set_meta(&tx, "last_index", &timestamp)?;
 
     tx.commit()?;
+
+    // Checkpoint the WAL so it doesn't grow unboundedly across indexing runs.
+    // Failure is non-fatal — the next run or SQLite's auto-checkpoint will
+    // eventually flush it.
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        tracing::debug!("WAL checkpoint after full_index failed (non-fatal): {e}");
+    }
 
     tracing::info!("indexing complete: {updated} updated, {skipped} skipped, {deleted} deleted");
     Ok(())
@@ -686,6 +712,15 @@ pub fn incremental_index(
         let mtime_ns = file_mtime_ns(&metadata);
         let size_bytes = metadata.len() as i64;
 
+        if metadata.len() > max_file_bytes() {
+            tracing::debug!(
+                "incremental: skipping oversized file {} ({} bytes)",
+                file_path.display(),
+                metadata.len()
+            );
+            continue;
+        }
+
         let source = match std::fs::read(file_path) {
             Ok(s) => s,
             Err(e) => {
@@ -785,9 +820,17 @@ pub fn incremental_index(
 
     resolve_symbol_references(&tx, &indexed, &imports_by_file)?;
 
-    // --- Phase 4: rebuild global derived tables ---
-    write::sync_fts(&tx)?;
-    write::rebuild_symbol_bodies(&tx, root)?;
+    // --- Phase 4: update derived tables ---
+    // Update FTS and body index only for the files that actually changed.
+    // This avoids the O(whole-codebase) full-table DELETE+re-insert that
+    // sync_fts / rebuild_symbol_bodies would trigger on every file-save
+    // event — the primary cause of unbounded WAL growth on large codebases.
+    // clear_file_content (called above per file) already removed the old
+    // FTS rows, so here we only need to insert the new ones.
+    for entry in &indexed {
+        write::insert_fts_for_file(&tx, entry.file_id)?;
+        write::rebuild_symbol_bodies_for_file(&tx, root, entry.file_id, &entry.rel_path)?;
+    }
     write::populate_unused_exports(&tx)?;
 
     let timestamp = std::time::SystemTime::now()
@@ -798,6 +841,12 @@ pub fn incremental_index(
     write::set_meta(&tx, "last_index", &timestamp)?;
 
     tx.commit()?;
+
+    // Checkpoint the WAL after each incremental index to prevent unbounded
+    // growth on large codebases with an active file watcher.
+    if let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+        tracing::debug!("WAL checkpoint after incremental_index failed (non-fatal): {e}");
+    }
 
     tracing::info!(
         "incremental index: {updated} updated, {removed} removed ({} changed, {} deleted input)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,63 +29,17 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Database ready at {}", config.db_path.display());
 
-    if config.has_project {
-        for root in &config.project_roots {
-            tracing::info!("Indexing root: {}", root.display());
-            index::full_index(&conn, root, config.reindex)?;
-        }
-        graph::pagerank::compute_pagerank(&conn, &Default::default())?;
-        graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())?;
-        git::cochange::analyze_cochanges(
-            &conn,
-            &config.primary_root,
-            &git::cochange::CoChangeConfig {
-                commit_limit: config.git_depth,
-                ..Default::default()
-            },
-        )?;
-        tracing::info!("Index complete for {} root(s)", config.project_roots.len());
-
-        if let Some(wiki_path) = cli.wiki.as_ref() {
-            let project_name = config
-                .primary_root
-                .canonicalize()
-                .ok()
-                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-                .or_else(|| {
-                    config
-                        .primary_root
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned())
-                })
-                .unwrap_or_else(|| "project".to_string());
-            let wiki_cfg = graph::wiki::WikiConfig {
-                project_name,
-                recompute: true,
-                leiden: graph::leiden::LeidenConfig {
-                    resolution: cli.leiden_resolution,
-                    ..Default::default()
-                },
-                ..Default::default()
-            };
-            let (markdown, modularity) = graph::wiki::render_wiki(&conn, &wiki_cfg)?;
-            let abs = config.primary_root.join(wiki_path);
-            if let Some(parent) = abs.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::write(&abs, &markdown)?;
-            tracing::info!(
-                "Wrote {} bytes to {} (modularity {:.2})",
-                markdown.len(),
-                abs.display(),
-                modularity.unwrap_or(0.0),
-            );
-        }
-    } else {
+    if !config.has_project {
         tracing::info!("No project detected, starting MCP server with empty index");
     }
 
-    let server = server::QartezServer::new(conn, config.primary_root, config.git_depth);
+    // Create the server immediately — this wraps `conn` in Arc<Mutex<Connection>>
+    // so the MCP transport can start and respond to `initialize` right away.
+    // Indexing is deferred to a background task spawned after the handshake.
+    let server = server::QartezServer::new(conn, config.primary_root.clone(), config.git_depth);
+
+    // Grab the shared DB handle before `serve()` consumes the server.
+    let db_for_index = server.db_arc();
 
     if !cli.no_watch && config.has_project {
         let db = server.db_arc();
@@ -100,8 +54,90 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    // Start the MCP transport. `serve()` completes the initialize handshake
+    // and returns — tools are immediately available to the client.
     let transport = (tokio::io::stdin(), tokio::io::stdout());
     let service = server.serve(transport).await?;
+
+    // Spawn indexing as a background blocking task so it doesn't block the
+    // handshake. Tool calls that arrive before indexing finishes will block
+    // briefly on the DB mutex — acceptable; not connecting at all is not.
+    if config.has_project {
+        let roots = config.project_roots.clone();
+        let primary_root = config.primary_root.clone();
+        let git_depth = config.git_depth;
+        let reindex = config.reindex;
+        let wiki_path = cli.wiki.clone();
+        let leiden_resolution = cli.leiden_resolution;
+
+        tokio::task::spawn_blocking(move || {
+            let conn = db_for_index.lock().expect("qartez db mutex poisoned");
+            for root in &roots {
+                tracing::info!("Indexing root: {}", root.display());
+                if let Err(e) = index::full_index(&conn, root, reindex) {
+                    tracing::error!("indexing error for {}: {e}", root.display());
+                }
+            }
+            if let Err(e) = graph::pagerank::compute_pagerank(&conn, &Default::default()) {
+                tracing::error!("pagerank failed: {e}");
+            }
+            if let Err(e) = graph::pagerank::compute_symbol_pagerank(&conn, &Default::default()) {
+                tracing::error!("symbol pagerank failed: {e}");
+            }
+            if let Err(e) = git::cochange::analyze_cochanges(
+                &conn,
+                &primary_root,
+                &git::cochange::CoChangeConfig {
+                    commit_limit: git_depth,
+                    ..Default::default()
+                },
+            ) {
+                tracing::error!("cochange analysis failed: {e}");
+            }
+            tracing::info!("Index complete for {} root(s)", roots.len());
+
+            if let Some(wiki_path) = wiki_path.as_ref() {
+                let project_name = primary_root
+                    .canonicalize()
+                    .ok()
+                    .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                    .or_else(|| {
+                        primary_root
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                    })
+                    .unwrap_or_else(|| "project".to_string());
+                let wiki_cfg = graph::wiki::WikiConfig {
+                    project_name,
+                    recompute: true,
+                    leiden: graph::leiden::LeidenConfig {
+                        resolution: leiden_resolution,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                match graph::wiki::render_wiki(&conn, &wiki_cfg) {
+                    Ok((markdown, modularity)) => {
+                        let abs = primary_root.join(wiki_path);
+                        if let Some(parent) = abs.parent() {
+                            let _ = std::fs::create_dir_all(parent);
+                        }
+                        if let Err(e) = std::fs::write(&abs, &markdown) {
+                            tracing::error!("failed to write wiki: {e}");
+                        } else {
+                            tracing::info!(
+                                "Wrote {} bytes to {} (modularity {:.2})",
+                                markdown.len(),
+                                abs.display(),
+                                modularity.unwrap_or(0.0),
+                            );
+                        }
+                    }
+                    Err(e) => tracing::error!("wiki generation failed: {e}"),
+                }
+            }
+        });
+    }
 
     service.waiting().await?;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,29 @@ use crate::error::Result;
 pub fn open_db(db_path: &Path) -> Result<Connection> {
     let conn = Connection::open(db_path)?;
 
+    // Enable incremental auto-vacuum for new databases so freed pages (e.g.
+    // from FTS table rebuilds during indexing) are reclaimed on disk rather
+    // than accumulating indefinitely. This must be set before any tables are
+    // created; for existing databases without auto_vacuum the change has no
+    // effect without a full VACUUM, which we skip here to avoid a long
+    // startup stall — WAL checkpointing after indexing is the primary
+    // mitigation for those.
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |r| r.get(0))
+        .unwrap_or(0);
+    if av == 0 {
+        let table_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if table_count == 0 {
+            conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")?;
+        }
+    }
+
     conn.execute_batch(
         "PRAGMA journal_mode = WAL;
          PRAGMA foreign_keys = ON;

--- a/src/storage/write.rs
+++ b/src/storage/write.rs
@@ -6,6 +6,10 @@ use crate::error::Result;
 use crate::storage::models::SymbolInsert;
 use crate::storage::read::get_file_by_path;
 
+/// Maximum lines stored per symbol body in `symbols_body_fts`. Caps FTS
+/// storage at a bounded size — very large functions are truncated.
+const MAX_BODY_LINES: usize = 500;
+
 pub fn upsert_file(
     conn: &Connection,
     path: &str,
@@ -247,13 +251,72 @@ pub fn rebuild_symbol_bodies(conn: &Connection, project_root: &std::path::Path) 
         let lines: Vec<&str> = text.lines().collect();
         for (id, line_start, line_end) in syms {
             let start = (line_start as usize).saturating_sub(1);
-            let end = (line_end as usize).min(lines.len());
+            let end = (line_end as usize)
+                .min(lines.len())
+                .min(start + MAX_BODY_LINES);
             if start >= lines.len() || start >= end {
                 continue;
             }
             let body = lines[start..end].join("\n");
             insert.execute(rusqlite::params![id, body])?;
         }
+    }
+    Ok(())
+}
+
+/// Insert `symbols_fts` entries for all symbols belonging to `file_id`.
+/// Called after `insert_symbols` during an incremental re-index so that only
+/// the affected file's entries are (re-)written rather than the whole table.
+/// `clear_file_content` must have already removed the old FTS rows for this
+/// file before this function is called.
+pub fn insert_fts_for_file(conn: &Connection, file_id: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO symbols_fts (rowid, name, kind, file_path)
+         SELECT s.id, s.name, s.kind, f.path
+         FROM symbols s
+         JOIN files f ON s.file_id = f.id
+         WHERE s.file_id = ?1",
+        [file_id],
+    )?;
+    Ok(())
+}
+
+/// Insert `symbols_body_fts` entries for the symbols in a single file.
+/// Called during incremental re-indexing instead of `rebuild_symbol_bodies`
+/// (which rebuilds every file) to avoid unbounded WAL growth on large
+/// codebases. `clear_file_content` must have already removed the old body
+/// FTS rows for this file before this function is called.
+pub fn rebuild_symbol_bodies_for_file(
+    conn: &Connection,
+    project_root: &Path,
+    file_id: i64,
+    rel_path: &str,
+) -> Result<()> {
+    let abs = project_root.join(rel_path);
+    let Ok(text) = std::fs::read_to_string(&abs) else {
+        return Ok(());
+    };
+    let lines: Vec<&str> = text.lines().collect();
+
+    let mut select =
+        conn.prepare("SELECT id, line_start, line_end FROM symbols WHERE file_id = ?1")?;
+    let syms: Vec<(i64, u32, u32)> = select
+        .query_map([file_id], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(select);
+
+    let mut insert =
+        conn.prepare("INSERT INTO symbols_body_fts (rowid, body) VALUES (?1, ?2)")?;
+    for (id, line_start, line_end) in syms {
+        let start = (line_start as usize).saturating_sub(1);
+        let end = (line_end as usize)
+            .min(lines.len())
+            .min(start + MAX_BODY_LINES);
+        if start >= lines.len() || start >= end {
+            continue;
+        }
+        let body = lines[start..end].join("\n");
+        insert.execute(rusqlite::params![id, body])?;
     }
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces several improvements to the indexing and storage subsystems, with a focus on performance, robustness, and scalability for large codebases. Major changes include limiting the size of indexed files and symbol bodies, optimizing incremental indexing to avoid unnecessary full-table operations, and enhancing SQLite database maintenance to prevent unbounded growth.

**Indexing performance and scalability:**

* Files larger than a configurable maximum size (default 1 MB, override via `QARTEZ_MAX_FILE_BYTES`) are now skipped during indexing, reducing noise from generated or irrelevant large files. (`src/index/mod.rs`) [[1]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R32-R41) [[2]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R72-R80) [[3]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R715-R723)
* During incremental indexing, only the affected files' FTS (full-text search) and symbol body indexes are updated, rather than rebuilding indexes for the entire codebase. This greatly reduces write amplification and WAL (Write-Ahead Log) growth. (`src/index/mod.rs`, `src/storage/write.rs`) [[1]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409L788-R833) [[2]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830R267-R323)

**Database maintenance and robustness:**

* After both full and incremental indexing runs, the WAL is checkpointed and truncated to prevent unbounded log file growth. Failures are logged but non-fatal. (`src/index/mod.rs`) [[1]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R221-R227) [[2]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R845-R850)
* New databases are initialized with SQLite's incremental auto-vacuum enabled, so freed pages are reclaimed on disk over time. For existing databases, this is a no-op unless a full VACUUM is performed. (`src/storage/mod.rs`)

**Symbol body and FTS storage limits:**

* The number of lines stored per symbol body in the FTS index is capped (default 500 lines) to prevent very large functions from bloating the index. (`src/storage/write.rs`) [[1]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830R9-R12) [[2]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830L250-R256)

**Startup and error handling improvements:**

* Indexing and analysis tasks are now spawned in background tasks after the server handshake, improving startup responsiveness. Errors in indexing, PageRank, cochange analysis, and wiki generation are logged but do not crash the server. (`src/main.rs`) [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR32-R105) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL66-L105)

These changes together improve the tool's efficiency, reliability, and scalability, especially for large and actively changing codebases.This pull request introduces several improvements to the indexing and storage subsystems, focusing on performance, resource usage, and scalability for large codebases. The main enhancements include skipping oversized files during indexing, optimizing how derived tables are updated to avoid unnecessary work, and implementing mechanisms to control SQLite database growth.

**Indexing optimizations and resource limits:**

- Added a file size limit (default 1 MB, configurable via `QARTEZ_MAX_FILE_BYTES`) to skip indexing of large files, which are typically generated and not useful for indexing. This applies to both full and incremental indexing. [[1]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R32-R41) [[2]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R72-R80) [[3]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R715-R723)
- Capped the number of lines stored per symbol body in the `symbols_body_fts` table to 500, preventing very large functions from bloating the FTS storage. [[1]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830R9-R12) [[2]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830L250-R256)

**Efficient updating of derived tables:**

- Changed incremental indexing to update FTS and symbol body tables only for files that changed, instead of rebuilding the entire table. This reduces unnecessary writes and helps prevent unbounded WAL growth. New helper functions `insert_fts_for_file` and `rebuild_symbol_bodies_for_file` were added for this purpose. [[1]](diffhunk://#diff-b953cf88986b5e03c58e3c736b26cc19367e33acb761849ca89e95fef7b3b830R267-R323) [[2]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409L788-R833)

**Database maintenance and growth control:**

- After both full and incremental indexing runs, the code now checkpoints the SQLite Write-Ahead Log (WAL) to prevent it from growing indefinitely, especially on large codebases. Failures are non-fatal and logged. [[1]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R221-R227) [[2]](diffhunk://#diff-f55f88198f6167505d2a0103ff23769d64c81189174326c87fc3c7f88ca0a409R845-R850)
- When opening a new database, incremental auto-vacuum is enabled if no tables exist yet, ensuring that freed pages are reclaimed and disk usage remains bounded.