### PR TITLE
feat(windows): native installer, hook portability, and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-matrix:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Setup binary tests
+        run: cargo test --bin qartez-setup -- --nocapture
+
+      - name: Guard hook tests
+        run: "cargo test --test tools guard_binary:: -- --nocapture"
+
+      - name: POSIX installer portability checks
+        if: runner.os != 'Windows'
+        run: bash ./tests/test-install.sh
+
+      - name: Windows installer dry-run checks
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./tests/test-install.ps1

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BENCH_RUN    = $(CARGO) run --quiet --release --features benchmark --bin benchma
 BENCH_LANGS := rust typescript python go java
 
 .PHONY: help test test-install build install deploy setup uninstall clean \
+        deploy-windows install-windows setup-windows \
         bench bench-all bench-fixtures
 
 help: ## Show this help
@@ -13,6 +14,9 @@ help: ## Show this help
 
 deploy: ## Full deploy: install deps, build, install, configure IDEs
 	@./install.sh
+
+deploy-windows: ## Full deploy on Windows PowerShell
+	@powershell -ExecutionPolicy Bypass -File .\install.ps1
 
 test: ## Run all tests
 	$(CARGO) test
@@ -41,6 +45,12 @@ install: build ## Build and install binaries to ~/.local/bin
 
 setup: ## Interactive IDE setup wizard (install deps + build + choose IDEs)
 	@./install.sh --interactive
+
+setup-windows: ## Interactive setup on Windows PowerShell
+	@powershell -ExecutionPolicy Bypass -File .\install.ps1 -Interactive
+
+install-windows: ## Build/install only on Windows PowerShell (skip IDE setup)
+	@powershell -ExecutionPolicy Bypass -File .\install.ps1 -SkipSetup
 
 uninstall: ## Remove qartez from all IDEs and uninstall binaries
 	@$(INSTALL_DIR)/qartez-setup --uninstall 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -49,12 +49,22 @@ The fix isn't a smarter model. It's a smarter index.
 
 ## Quickstart
 
-**Prerequisites:** macOS or Linux (Windows via [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install)). Rust toolchain is installed automatically if missing.
+**Prerequisites:**
+- **macOS / Linux**: curl + POSIX shell (`sh`)
+- **Windows (native)**: PowerShell 5.1+ (or PowerShell 7+)
+
+Rust toolchain is installed automatically if missing.
 
 One command to install:
 
 ```bash
 curl -sSfL https://qartez.dev/install | sh
+```
+
+Windows (native PowerShell):
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "iwr https://qartez.dev/install.ps1 -useb | iex"
 ```
 
 The installer checks for Rust (installs via [rustup](https://rustup.rs/) if missing), builds the release binaries, installs them to `~/.local/bin/`, and launches `qartez-setup` in non-interactive mode - it auto-detects every MCP-capable IDE on your machine and configures them all in one pass, including the modification-guard hooks for Claude Code.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,208 @@
+param(
+    [switch]$Interactive,
+    [switch]$SkipSetup,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Qartez MCP — native Windows installer
+# Usage:
+#   powershell -ExecutionPolicy Bypass -c "iwr https://qartez.dev/install.ps1 -useb | iex"
+#
+# From a checked-out repo:
+#   .\install.ps1
+
+$Repo = 'kuberstar/qartez-mcp'
+$Branch = 'main'
+$InstallDir = Join-Path $env:LOCALAPPDATA 'Programs\qartez\bin'
+
+function Write-Info([string]$Message) { Write-Host "==> $Message" -ForegroundColor Cyan }
+function Write-Ok([string]$Message) { Write-Host "[+] $Message" -ForegroundColor Green }
+function Write-Warn([string]$Message) { Write-Host "[!] $Message" -ForegroundColor Yellow }
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string]$File,
+        [Parameter(Mandatory = $true)][string[]]$Args
+    )
+    if ($DryRun) {
+        Write-Info "[dry-run] $File $($Args -join ' ')"
+        return
+    }
+
+    & $File @Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed ($LASTEXITCODE): $File $($Args -join ' ')"
+    }
+}
+
+function Add-ToUserPath {
+    param([Parameter(Mandatory = $true)][string]$PathToAdd)
+
+    $current = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    if ([string]::IsNullOrWhiteSpace($current)) {
+        $newPath = $PathToAdd
+    }
+    elseif ($current -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -eq $PathToAdd }) {
+        return
+    }
+    else {
+        $newPath = "$PathToAdd;$current"
+    }
+
+    if ($DryRun) {
+        Write-Info "[dry-run] Set user PATH to include: $PathToAdd"
+        return
+    }
+
+    [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+    if (-not (($env:PATH -split ';') -contains $PathToAdd)) {
+        $env:PATH = "$PathToAdd;$env:PATH"
+    }
+}
+
+function Resolve-SourceDirectory {
+    # Repo mode: script sits next to Cargo.toml
+    $repoDir = if ($PSCommandPath) {
+        Split-Path -Parent $PSCommandPath
+    }
+    else {
+        (Get-Location).Path
+    }
+    $cargoToml = Join-Path $repoDir 'Cargo.toml'
+    if (Test-Path -Path $cargoToml -PathType Leaf) {
+        return $repoDir
+    }
+
+    # Download source archive from GitHub and extract
+    Write-Info "Source not found locally - downloading from github.com/$Repo..."
+
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("qartez-install-" + [guid]::NewGuid().ToString('N'))
+    $archive = Join-Path $tmp 'qartez.zip'
+    $extractDir = Join-Path $tmp 'src'
+    if (-not $DryRun) {
+        New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+        $url = "https://codeload.github.com/$Repo/zip/refs/heads/$Branch"
+        Invoke-WebRequest -Uri $url -OutFile $archive -UseBasicParsing
+        Expand-Archive -Path $archive -DestinationPath $extractDir -Force
+    }
+    else {
+        Write-Info "[dry-run] Download and extract source archive from github"
+        return $repoDir
+    }
+
+    $sourceDir = Get-ChildItem -Path $extractDir -Directory | Select-Object -First 1
+    if (-not $sourceDir) {
+        throw 'Unexpected source archive layout (no extracted root directory found).'
+    }
+    $sourceCargoToml = Join-Path $sourceDir.FullName 'Cargo.toml'
+    if (-not (Test-Path -Path $sourceCargoToml -PathType Leaf)) {
+        throw "Unexpected source archive layout: $sourceCargoToml not found"
+    }
+
+    return $sourceDir.FullName
+}
+
+function Ensure-Cargo {
+    $cargo = Get-Command cargo -ErrorAction SilentlyContinue
+    if ($cargo) {
+        return $cargo.Source
+    }
+
+    $cargoHomeBin = Join-Path $env:USERPROFILE '.cargo\bin'
+    $cargoExe = Join-Path $cargoHomeBin 'cargo.exe'
+    if (Test-Path -Path $cargoExe -PathType Leaf) {
+        if (-not (($env:PATH -split ';') -contains $cargoHomeBin)) {
+            $env:PATH = "$cargoHomeBin;$env:PATH"
+        }
+        return $cargoExe
+    }
+
+    Write-Info 'Rust not found. Installing via rustup...'
+    $rustupInit = Join-Path ([System.IO.Path]::GetTempPath()) 'rustup-init.exe'
+    if (-not $DryRun) {
+        Invoke-WebRequest -Uri 'https://win.rustup.rs/x86_64' -OutFile $rustupInit -UseBasicParsing
+        Invoke-Checked -File $rustupInit -Args @('-y')
+        Remove-Item -Path $rustupInit -Force -ErrorAction SilentlyContinue
+    }
+    else {
+        Write-Info '[dry-run] Download and run rustup-init.exe -y'
+    }
+
+    if (-not (($env:PATH -split ';') -contains $cargoHomeBin)) {
+        $env:PATH = "$cargoHomeBin;$env:PATH"
+    }
+
+    if ($DryRun) {
+        return $cargoExe
+    }
+
+    if (-not (Test-Path -Path $cargoExe -PathType Leaf)) {
+        throw "cargo not found at $cargoExe after rustup install"
+    }
+    Write-Ok 'Rust installed.'
+    return $cargoExe
+}
+
+Write-Info 'Installing qartez-mcp (Windows native)...'
+
+$sourceDir = Resolve-SourceDirectory
+$cargoPath = Ensure-Cargo
+
+Write-Info 'Building release binaries (first build may take a few minutes)...'
+$oldLocation = Get-Location
+try {
+    Set-Location $sourceDir
+    Invoke-Checked -File $cargoPath -Args @('build', '--release')
+}
+finally {
+    Set-Location $oldLocation
+}
+
+$targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { Join-Path $sourceDir 'target' }
+$releaseDir = Join-Path $targetDir 'release'
+
+if (-not $DryRun) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+else {
+    Write-Info "[dry-run] Ensure install directory exists: $InstallDir"
+}
+
+foreach ($bin in @('qartez-mcp', 'qartez-guard', 'qartez-setup')) {
+    $src = Join-Path $releaseDir ($bin + '.exe')
+    if (-not $DryRun -and -not (Test-Path -Path $src -PathType Leaf)) {
+        throw "Binary not found: $src"
+    }
+
+    $tmp = Join-Path $InstallDir ($bin + '.new.exe')
+    $dst = Join-Path $InstallDir ($bin + '.exe')
+    if (-not $DryRun) {
+        Copy-Item -Path $src -Destination $tmp -Force
+        Move-Item -Path $tmp -Destination $dst -Force
+        $sizeMB = (Get-Item $src).Length / 1MB
+        Write-Ok ("Installed: {0} ({1:N1} MB)" -f $dst, $sizeMB)
+    }
+    else {
+        Write-Info "[dry-run] Install $src -> $dst (atomic via *.new.exe)"
+    }
+}
+
+Add-ToUserPath -PathToAdd $InstallDir
+Write-Ok "User PATH includes: $InstallDir"
+
+$setupExe = Join-Path $InstallDir 'qartez-setup.exe'
+if ($Interactive) {
+    Write-Info 'Launching interactive IDE setup...'
+    Invoke-Checked -File $setupExe -Args @()
+}
+elseif ($SkipSetup) {
+    Write-Info 'Skipping IDE setup (--SkipSetup).'
+}
+else {
+    Write-Info 'Configuring all detected IDEs...'
+    Invoke-Checked -File $setupExe -Args @('--yes')
+}
+
+Write-Ok 'Install complete. Restart your terminal and IDEs to pick up PATH/MCP changes.'

--- a/src/bin/guard.rs
+++ b/src/bin/guard.rs
@@ -77,6 +77,42 @@ fn run() -> anyhow::Result<()> {
         Err(_) => return Ok(()),
     };
 
+    let tool_name_lower = hook.tool_name.to_lowercase();
+
+    // Glob/Grep guard: deny when .qartez exists (qartez tools should be used instead)
+    // Supports both Claude (Glob, Grep) and Gemini (glob, grep_search) tool names
+    if matches!(
+        tool_name_lower.as_str(),
+        "glob" | "grep" | "grep_search"
+    ) {
+        let hook_cwd = hook.cwd.clone();
+        let project_root = match cli.project_root.clone() {
+            Some(r) => Some(r),
+            None => hook_cwd
+                .as_ref()
+                .and_then(|cwd| guard::find_project_root(std::path::Path::new(cwd))),
+        };
+        if let Some(root) = project_root {
+            if root.join(".qartez").is_dir() {
+                let reason = if tool_name_lower == "glob" || tool_name_lower == "grep_search" {
+                    "STOP: qartez MCP is available. Use `qartez_map` for project structure or `qartez_find` to locate symbols. Use Glob ONLY for non-code file patterns (e.g., *.toml, *.json) — if so, use Bash find/ls instead."
+                } else {
+                    "STOP: qartez MCP is available. Use `qartez_grep` for symbol search or `qartez_find` for definitions. Use Grep ONLY for non-symbol text search (e.g., TODO comments, string literals) — if so, use Bash grep instead."
+                };
+                if let Some(json) = guard::render_stdout(
+                    &guard::GuardDecision::Deny {
+                        reason: reason.to_string(),
+                    },
+                    hook.hook_event_name.as_deref(),
+                ) {
+                    println!("{json}");
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    // Modification guard: only handle Edit/Write/MultiEdit and variants
     if !matches!(
         hook.tool_name.as_str(),
         "Edit" | "Write" | "MultiEdit" | "replace" | "write_file"
@@ -104,16 +140,55 @@ fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let Some(rel_path) = guard::relativize_file_path(&project_root, &file_path) else {
+    let Some(rel_path_raw) = guard::relativize_file_path(&project_root, &file_path) else {
         return Ok(());
     };
+    // Normalize to repo-style logical path for messaging + ack hashing.
+    // Keep lookup tolerant by probing multiple variants below.
+    let rel_path = rel_path_raw
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string();
 
     let conn = match open_read_only(&db_path) {
         Ok(c) => c,
         Err(_) => return Ok(()),
     };
 
-    let Some(file_row) = read::get_file_by_path(&conn, &rel_path).ok().flatten() else {
+    // Windows path canonicalization can yield backslashes while the index may
+    // store forward slashes. Probe both normalized variants before fail-open.
+    // Also handle db rows prefixed with "./".
+    let slash = rel_path.clone();
+    let backslash = rel_path.replace('/', "\\");
+    let slash_dot = format!("./{slash}");
+    let backslash_dot = format!(".\\{backslash}");
+    let candidates = [
+        rel_path.as_str(),
+        slash.as_str(),
+        backslash.as_str(),
+        slash_dot.as_str(),
+        backslash_dot.as_str(),
+    ];
+    let mut file_row = candidates
+        .iter()
+        .find_map(|candidate| read::get_file_by_path(&conn, candidate).ok().flatten());
+    if file_row.is_none()
+        && let Ok(files) = read::get_all_files(&conn)
+    {
+        let norm = |s: &str| {
+            s.replace('\\', "/")
+                .trim_start_matches("./")
+                .trim_start_matches('/')
+                .to_string()
+        };
+        let targets: Vec<String> = candidates.iter().map(|c| norm(c)).collect();
+        file_row = files.into_iter().find(|f| {
+            let p = norm(&f.path);
+            targets.iter().any(|t| p == *t || p.ends_with(&format!("/{t}")))
+        });
+    }
+    let Some(file_row) = file_row else {
         return Ok(());
     };
 

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -19,8 +19,6 @@ use dialoguer::MultiSelect;
 
 // -- Embedded hook assets (source of truth lives in scripts/) ----------------
 
-const GUARD_HOOK_SH: &str = include_str!("../../scripts/qartez-guard.sh");
-const SESSION_START_SH: &str = include_str!("../../scripts/qartez-session-start.sh");
 const CLAUDE_MD_SNIPPET: &str = include_str!("../../scripts/CLAUDE.md.snippet");
 const AGENTS_MD_SNIPPET: &str = include_str!("../../scripts/AGENTS.md.snippet");
 const CURSOR_RULE_MDC: &str = include_str!("../../scripts/cursor-rule.mdc");
@@ -793,17 +791,9 @@ fn install_claude_one(claude_dir: &Path, bin: &str, _guard_bin: Option<&str>) ->
 
     info(&format!("» {}", claude_dir.display()));
 
-    // 1. Install hook scripts
-    fs::create_dir_all(&hooks_dir)?;
-    let guard_sh = hooks_dir.join("qartez-guard.sh");
-    fs::write(&guard_sh, GUARD_HOOK_SH)?;
-    make_executable(&guard_sh)?;
-    info(&format!("Hook installed: {}", guard_sh.display()));
-
-    let session_sh = hooks_dir.join("qartez-session-start.sh");
-    fs::write(&session_sh, SESSION_START_SH)?;
-    make_executable(&session_sh)?;
-    info(&format!("Hook installed: {}", session_sh.display()));
+    // Remove legacy shell hook wrappers. Hooks are configured to invoke
+    // binaries directly, so shell scripts are no longer required.
+    remove_legacy_hook_files(&hooks_dir)?;
 
     // 2. Configure settings.json
     ensure_parent(&settings_path)?;
@@ -1051,17 +1041,9 @@ fn install_gemini_one(gemini_dir: &Path, bin: &str, _guard_bin: Option<&str>) ->
 
     info(&format!("» {}", gemini_dir.display()));
 
-    // 1. Install hook scripts
-    fs::create_dir_all(&hooks_dir)?;
-    let guard_sh = hooks_dir.join("qartez-guard.sh");
-    fs::write(&guard_sh, GUARD_HOOK_SH)?;
-    make_executable(&guard_sh)?;
-    info(&format!("Hook installed: {}", guard_sh.display()));
-
-    let session_sh = hooks_dir.join("qartez-session-start.sh");
-    fs::write(&session_sh, SESSION_START_SH)?;
-    make_executable(&session_sh)?;
-    info(&format!("Hook installed: {}", session_sh.display()));
+    // Remove legacy shell hook wrappers. Hooks are configured to invoke
+    // binaries directly, so shell scripts are no longer required.
+    remove_legacy_hook_files(&hooks_dir)?;
 
     // 2. Configure settings.json
     ensure_parent(&settings_path)?;
@@ -1155,7 +1137,12 @@ fn uninstall_gemini_one(gemini_dir: &Path) -> anyhow::Result<()> {
 
     info(&format!("» {}", gemini_dir.display()));
 
-    for name in ["qartez-guard.sh", "qartez-session-start.sh"] {
+    for name in [
+        "qartez-guard.sh",
+        "qartez-session-start.sh",
+        "qartez-guard.ps1",
+        "qartez-session-start.ps1",
+    ] {
         let path = hooks_dir.join(name);
         if path.is_file() {
             fs::remove_file(&path)?;
@@ -1496,7 +1483,12 @@ fn uninstall_claude_one(claude_dir: &Path) -> anyhow::Result<()> {
     info(&format!("» {}", claude_dir.display()));
 
     // Remove hook files
-    for name in ["qartez-guard.sh", "qartez-session-start.sh"] {
+    for name in [
+        "qartez-guard.sh",
+        "qartez-session-start.sh",
+        "qartez-guard.ps1",
+        "qartez-session-start.ps1",
+    ] {
         let path = hooks_dir.join(name);
         if path.is_file() {
             fs::remove_file(&path)?;
@@ -1581,6 +1573,22 @@ fn remove_hook_entries_containing(
             settings["hooks"][hook_type] = serde_json::Value::Array(filtered);
         }
     }
+}
+
+fn remove_legacy_hook_files(hooks_dir: &Path) -> anyhow::Result<()> {
+    for name in [
+        "qartez-guard.sh",
+        "qartez-session-start.sh",
+        "qartez-guard.ps1",
+        "qartez-session-start.ps1",
+    ] {
+        let path = hooks_dir.join(name);
+        if path.is_file() {
+            fs::remove_file(&path)?;
+            info(&format!("Legacy hook removed: {}", path.display()));
+        }
+    }
+    Ok(())
 }
 
 // -- Cursor / Windsurf (shared JSON mcpServers pattern) ----------------------
@@ -2441,21 +2449,6 @@ fn current_codex_binary(content: &str) -> Option<String> {
     None
 }
 
-// -- Platform helpers --------------------------------------------------------
-
-#[cfg(unix)]
-fn make_executable(path: &Path) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let perms = fs::Permissions::from_mode(0o755);
-    fs::set_permissions(path, perms)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn make_executable(_path: &Path) -> anyhow::Result<()> {
-    Ok(())
-}
-
 // -- Main --------------------------------------------------------------------
 
 fn main() -> ExitCode {
@@ -2974,6 +2967,13 @@ mod tests {
     // Serializes tests that mutate process-global env vars ($HOME, $PATH).
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        match ENV_LOCK.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
     struct EnvGuard {
         key: &'static str,
         original: Option<std::ffi::OsString>,
@@ -3002,7 +3002,7 @@ mod tests {
 
     #[test]
     fn update_cache_missing_is_not_fresh() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         assert!(!update_cache_is_fresh());
@@ -3010,7 +3010,7 @@ mod tests {
 
     #[test]
     fn update_cache_fresh_after_touch() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         touch_update_cache();
@@ -3019,7 +3019,7 @@ mod tests {
 
     #[test]
     fn update_cache_stale_when_mtime_exceeds_ttl() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         touch_update_cache();
@@ -3039,7 +3039,7 @@ mod tests {
 
     #[test]
     fn acquire_lock_succeeds_and_creates_file() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         let lock = acquire_update_lock();
@@ -3048,8 +3048,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn acquire_lock_returns_none_for_unwritable_lock_file() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         let dir = tmp.path().join(".qartez");
@@ -3072,7 +3073,7 @@ mod tests {
 
     #[test]
     fn lock_released_on_drop_allows_reacquire() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         let _home = EnvGuard::set("HOME", tmp.path());
         {
@@ -3106,6 +3107,58 @@ mod tests {
         assert!(is_newer_version("v1.0.1-beta", "1.0.0"));
     }
 
+    #[test]
+    fn install_claude_removes_legacy_shell_hooks_and_uses_binary_session_start() {
+        let _mu = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = EnvGuard::set("HOME", tmp.path());
+
+        let claude_dir = tmp.path().join(".claude");
+        let hooks = claude_dir.join("hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        fs::write(hooks.join("qartez-guard.sh"), "#!/bin/sh\n").unwrap();
+        fs::write(hooks.join("qartez-session-start.sh"), "#!/bin/sh\n").unwrap();
+
+        install_claude_one(&claude_dir, "qartez-mcp", None).unwrap();
+
+        assert!(!hooks.join("qartez-guard.sh").exists());
+        assert!(!hooks.join("qartez-session-start.sh").exists());
+
+        let settings = read_json(&claude_dir.join("settings.json")).unwrap();
+        let session_cmd = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(session_cmd.contains("qartez-setup"));
+        assert!(session_cmd.contains("--session-start"));
+        assert!(!session_cmd.contains(".sh"));
+    }
+
+    #[test]
+    fn install_gemini_removes_legacy_shell_hooks_and_uses_binary_session_start() {
+        let _mu = env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = EnvGuard::set("HOME", tmp.path());
+
+        let gemini_dir = tmp.path().join(".gemini");
+        let hooks = gemini_dir.join("hooks");
+        fs::create_dir_all(&hooks).unwrap();
+        fs::write(hooks.join("qartez-guard.sh"), "#!/bin/sh\n").unwrap();
+        fs::write(hooks.join("qartez-session-start.sh"), "#!/bin/sh\n").unwrap();
+
+        install_gemini_one(&gemini_dir, "qartez-mcp", None).unwrap();
+
+        assert!(!hooks.join("qartez-guard.sh").exists());
+        assert!(!hooks.join("qartez-session-start.sh").exists());
+
+        let settings = read_json(&gemini_dir.join("settings.json")).unwrap();
+        let session_cmd = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(session_cmd.contains("qartez-setup"));
+        assert!(session_cmd.contains("--session-start"));
+        assert!(!session_cmd.contains(".sh"));
+    }
+
     // -- Mock curl for fetch_latest_release_tag ----------------------------
 
     #[cfg(unix)]
@@ -3127,7 +3180,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn fetch_release_tag_parses_valid_github_response() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         write_mock_curl(tmp.path(), r#"{"tag_name": "v0.2.0"}"#);
         let orig = std::env::var("PATH").unwrap_or_default();
@@ -3138,7 +3191,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn fetch_release_tag_rejects_invalid_json() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         write_mock_curl(tmp.path(), "not json");
         let orig = std::env::var("PATH").unwrap_or_default();
@@ -3149,7 +3202,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn fetch_release_tag_rejects_missing_tag_name() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         write_mock_curl(tmp.path(), r#"{"name": "Release"}"#);
         let orig = std::env::var("PATH").unwrap_or_default();
@@ -3160,7 +3213,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn fetch_release_tag_returns_error_on_curl_failure() {
-        let _mu = ENV_LOCK.lock().unwrap();
+        let _mu = env_lock();
         let tmp = tempfile::tempdir().unwrap();
         write_mock_curl_failing(tmp.path(), 22);
         let orig = std::env::var("PATH").unwrap_or_default();

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -2605,6 +2605,93 @@ fn download_semantic_model() -> anyhow::Result<()> {
     Ok(())
 }
 
+// -- Session-start hook (Rust equivalent of qartez-session-start.sh) ----------
+
+/// Repo markers that indicate this is a real code project (not a random folder).
+const REPO_MARKERS: &[&str] = &[
+    ".git",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "go.mod",
+];
+
+/// Rust implementation of the session-start hook behavior.
+/// Mirrors `scripts/qartez-session-start.sh` but requires no bash.
+fn run_session_start() -> anyhow::Result<()> {
+    let project_dir = std::env::var("CLAUDE_PROJECT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+
+    if project_dir.as_os_str().is_empty() || !project_dir.is_dir() {
+        return Ok(());
+    }
+
+    // Skip dangerous roots
+    let home = home_dir();
+    if project_dir == home || project_dir == PathBuf::from("/") {
+        return Ok(());
+    }
+
+    // Already indexed
+    if project_dir.join(".qartez").is_dir() {
+        return Ok(());
+    }
+
+    // Require at least one repo marker
+    let has_marker = REPO_MARKERS.iter().any(|m| project_dir.join(m).exists());
+    if !has_marker {
+        return Ok(());
+    }
+
+    // Locate qartez-mcp binary
+    let binary = find_binary("qartez-mcp").or_else(|| {
+        // Fallback: check QARTEZ_BINARY env var
+        std::env::var("QARTEZ_BINARY")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|p| p.is_file())
+    });
+
+    let Some(binary) = binary else {
+        return Ok(());
+    };
+
+    // Spawn detached background reindex
+    let log_dir = home.join(".cache").join("qartez-mcp");
+    let _ = fs::create_dir_all(&log_dir);
+    let log_file = log_dir.join("session-index.log");
+
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new(&binary)
+            .arg("--root")
+            .arg(&project_dir)
+            .arg("--reindex")
+            .stdout(fs::OpenOptions::new().create(true).append(true).open(&log_file)?)
+            .stderr(fs::OpenOptions::new().create(true).append(true).open(&log_file)?)
+            .stdin(Stdio::null())
+            .spawn();
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED: u32 = 0x00000008;
+        let mut cmd = std::process::Command::new(&binary);
+        cmd.arg("--root")
+            .arg(&project_dir)
+            .arg("--reindex")
+            .stdout(fs::OpenOptions::new().create(true).append(true).open(&log_file)?)
+            .stderr(fs::OpenOptions::new().create(true).append(true).open(&log_file)?)
+            .stdin(Stdio::null())
+            .creation_flags(DETACHED);
+        cmd.spawn().ok();
+    }
+
+    Ok(())
+}
+
 // -- Auto-update -------------------------------------------------------------
 
 const QARTEZ_UPDATE_REPO: &str = "kuberstar/qartez-mcp";

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -63,6 +63,13 @@ struct Cli {
     /// (24h TTL) and silent on no-op. Used by qartez-mcp on startup.
     #[arg(long, hide = true)]
     update_background: bool,
+
+    /// Internal flag: session-start hook entry point.
+    /// Implements the auto-indexing behavior from qartez-session-start.sh in Rust.
+    /// Detects project, checks for .qartez marker, validates repo markers,
+    /// locates qartez-mcp binary, and spawns a detached background reindex.
+    #[arg(long, hide = true)]
+    session_start: bool,
 }
 
 // -- IDE registry ------------------------------------------------------------
@@ -330,10 +337,30 @@ fn home_dir() -> PathBuf {
 }
 
 /// Portable home directory lookup without pulling in the `dirs` crate.
+/// Checks HOME (Unix), USERPROFILE (Windows), HOMEDRIVE+HOMEPATH (Windows),
+/// then falls back to current directory.
 fn dirs_replacement() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .expect("$HOME is not set")
+    // Try HOME (Unix)
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home);
+    }
+    // Try USERPROFILE (Windows)
+    if let Some(profile) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(profile);
+    }
+    // Try HOMEDRIVE+HOMEPATH (Windows fallback)
+    if let (Some(drive), Some(path)) = (
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+    ) {
+        let mut combined = PathBuf::from(drive);
+        combined.push(path);
+        if combined.is_dir() {
+            return combined;
+        }
+    }
+    // Fallback to current directory
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
 /// Claude Desktop's config directory varies by platform.
@@ -576,6 +603,7 @@ fn strip_jsonc(text: &str) -> String {
 /// Find the qartez-mcp binary, checking standard locations.
 fn find_binary(name: &str) -> Option<PathBuf> {
     let home = home_dir();
+
     let candidates = [
         home.join(".local").join("bin").join(name),
         // Also try the cargo target dir relative to this binary
@@ -588,6 +616,13 @@ fn find_binary(name: &str) -> Option<PathBuf> {
         if c.is_file() {
             return Some(c.clone());
         }
+        // On Windows, try with .exe suffix
+        if cfg!(windows) {
+            let with_exe = c.with_extension("exe");
+            if with_exe.is_file() {
+                return Some(with_exe);
+            }
+        }
     }
     // Check PATH
     which_in_path(name)
@@ -596,9 +631,19 @@ fn find_binary(name: &str) -> Option<PathBuf> {
 fn which_in_path(name: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path_var) {
+        // Try the bare name first
         let candidate = dir.join(name);
         if candidate.is_file() {
             return Some(candidate);
+        }
+        // On Windows, also try with common executable extensions
+        if cfg!(windows) {
+            for ext in &["exe", "cmd", "bat", "com"] {
+                let with_ext = dir.join(format!("{}.{}", name, ext));
+                if with_ext.is_file() {
+                    return Some(with_ext);
+                }
+            }
         }
     }
     None
@@ -742,7 +787,7 @@ fn install_claude(bin: &str, guard_bin: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn install_claude_one(claude_dir: &Path, bin: &str, guard_bin: Option<&str>) -> anyhow::Result<()> {
+fn install_claude_one(claude_dir: &Path, bin: &str, _guard_bin: Option<&str>) -> anyhow::Result<()> {
     let hooks_dir = claude_dir.join("hooks");
     let settings_path = claude_dir.join("settings.json");
 
@@ -769,23 +814,31 @@ fn install_claude_one(claude_dir: &Path, bin: &str, guard_bin: Option<&str>) -> 
         settings["hooks"] = serde_json::json!({});
     }
 
-    // Absolute hook commands so they resolve regardless of which claude
-    // home the shell's `~` currently refers to.
-    let guard_cmd = format!("bash {}", guard_sh.display());
-    let session_cmd = format!("bash {}", session_sh.display());
+    // Use qartez-guard binary directly (no bash dependency)
+    let guard_bin_path = find_binary("qartez-guard").map(|p| p.to_string_lossy().into_owned());
+
+    // Use qartez-setup --session-start for session start hook (no bash dependency)
+    let setup_bin_path = find_binary("qartez-setup")
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "qartez-setup".to_string());
+    let session_cmd = format!("{} --session-start", setup_bin_path);
 
     // PreToolUse: Glob|Grep guard
-    ensure_hook_entry(
-        &mut settings,
-        "PreToolUse",
-        "Glob|Grep",
-        "qartez-guard",
-        &guard_cmd,
-        3000,
-    );
+    if let Some(guard) = guard_bin_path.as_deref() {
+        ensure_hook_entry(
+            &mut settings,
+            "PreToolUse",
+            "Glob|Grep",
+            "qartez-guard",
+            guard,
+            3000,
+        );
+    } else {
+        warn("qartez-guard binary not found; glob/grep guard hook skipped");
+    }
 
     // PreToolUse: Edit|Write|MultiEdit modification guard
-    if let Some(guard) = guard_bin {
+    if let Some(guard) = guard_bin_path.as_deref() {
         ensure_hook_entry(
             &mut settings,
             "PreToolUse",
@@ -992,7 +1045,7 @@ fn install_gemini(bin: &str, guard_bin: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn install_gemini_one(gemini_dir: &Path, bin: &str, guard_bin: Option<&str>) -> anyhow::Result<()> {
+fn install_gemini_one(gemini_dir: &Path, bin: &str, _guard_bin: Option<&str>) -> anyhow::Result<()> {
     let hooks_dir = gemini_dir.join("hooks");
     let settings_path = gemini_dir.join("settings.json");
 
@@ -1018,21 +1071,31 @@ fn install_gemini_one(gemini_dir: &Path, bin: &str, guard_bin: Option<&str>) -> 
         settings["hooks"] = serde_json::json!({});
     }
 
-    let guard_cmd = format!("bash {}", guard_sh.display());
-    let session_cmd = format!("bash {}", session_sh.display());
+    // Use qartez-guard binary directly (no bash dependency)
+    let guard_bin_path = find_binary("qartez-guard").map(|p| p.to_string_lossy().into_owned());
+
+    // Use qartez-setup --session-start for session start hook (no bash dependency)
+    let setup_bin_path = find_binary("qartez-setup")
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "qartez-setup".to_string());
+    let session_cmd = format!("{} --session-start", setup_bin_path);
 
     // BeforeTool: glob|grep_search guard
-    ensure_hook_entry(
-        &mut settings,
-        "BeforeTool",
-        "glob|grep_search",
-        "qartez-guard",
-        &guard_cmd,
-        3000,
-    );
+    if let Some(guard) = guard_bin_path.as_deref() {
+        ensure_hook_entry(
+            &mut settings,
+            "BeforeTool",
+            "glob|grep_search",
+            "qartez-guard",
+            guard,
+            3000,
+        );
+    } else {
+        warn("qartez-guard binary not found; glob/grep guard hook skipped");
+    }
 
     // BeforeTool: replace|write_file modification guard
-    if let Some(guard) = guard_bin {
+    if let Some(guard) = guard_bin_path.as_deref() {
         ensure_hook_entry(
             &mut settings,
             "BeforeTool",
@@ -1041,6 +1104,8 @@ fn install_gemini_one(gemini_dir: &Path, bin: &str, guard_bin: Option<&str>) -> 
             guard,
             3000,
         );
+    } else {
+        warn("qartez-guard binary not found; modification guard hook skipped");
     }
 
     // SessionStart: auto-indexing
@@ -2406,6 +2471,10 @@ fn main() -> ExitCode {
 fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    if cli.session_start {
+        return run_session_start();
+    }
+
     if cli.update || cli.update_background {
         return run_update(cli.update_background);
     }
@@ -2546,6 +2615,7 @@ fn download_semantic_model() -> anyhow::Result<()> {
 // -- Auto-update -------------------------------------------------------------
 
 const QARTEZ_UPDATE_REPO: &str = "kuberstar/qartez-mcp";
+#[cfg(unix)]
 const QARTEZ_INSTALL_URL: &str =
     "https://raw.githubusercontent.com/kuberstar/qartez-mcp/main/install.sh";
 const UPDATE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
@@ -2707,31 +2777,48 @@ fn run_update(background: bool) -> anyhow::Result<()> {
         latest.trim_start_matches('v'),
     );
 
-    let install_cmd = format!("curl -sSfL {QARTEZ_INSTALL_URL} | sh");
-    let mut child = Command::new("sh")
-        .arg("-c")
-        .arg(&install_cmd)
-        .stdin(Stdio::null())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn installer: {e}"))?;
-    let status = child
-        .wait()
-        .map_err(|e| anyhow::anyhow!("installer wait failed: {e}"))?;
+#[cfg(unix)]
+    {
+        let install_cmd = format!("curl -sSfL {QARTEZ_INSTALL_URL} | sh");
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&install_cmd)
+            .stdin(Stdio::null())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn installer: {e}"))?;
+        let status = child
+            .wait()
+            .map_err(|e| anyhow::anyhow!("installer wait failed: {e}"))?;
 
-    if !status.success() {
-        anyhow::bail!(
-            "installer exited with status {}",
-            status.code().unwrap_or(-1)
+        if !status.success() {
+            anyhow::bail!(
+                "installer exited with status {}",
+                status.code().unwrap_or(-1)
+            );
+        }
+
+        touch_update_cache();
+        eprintln!(
+            " {} Update complete: {} → {}",
+            style("✓").green().bold(),
+            current,
+            latest.trim_start_matches('v'),
         );
     }
 
-    touch_update_cache();
-    eprintln!(
-        "  {} Update complete: {} → {}",
-        style("✓").green().bold(),
-        current,
-        latest.trim_start_matches('v'),
-    );
+    #[cfg(windows)]
+    {
+        eprintln!(
+            " {} Auto-update on Windows requires WSL or Git Bash.",
+            style("[!]").yellow()
+        );
+        eprintln!(
+            " {} Visit https://github.com/kuberstar/qartez-mcp/releases to download v{} manually.",
+            style("[i]").cyan(),
+            latest.trim_start_matches('v'),
+        );
+    }
+
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,10 +247,33 @@ fn expand_roots_with_workspaces(roots: Vec<PathBuf>) -> Vec<PathBuf> {
     expanded
 }
 
+/// Cross-platform home directory detection.
+/// Checks HOME (Unix), USERPROFILE (Windows), HOMEDRIVE+HOMEPATH (Windows).
+fn cross_platform_home() -> Option<PathBuf> {
+    // Try HOME (Unix)
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(home));
+    }
+    // Try USERPROFILE (Windows)
+    if let Some(profile) = std::env::var_os("USERPROFILE") {
+        return Some(PathBuf::from(profile));
+    }
+    // Try HOMEDRIVE+HOMEPATH (Windows fallback)
+    if let (Some(drive), Some(path)) = (
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+    ) {
+        let mut combined = PathBuf::from(drive);
+        combined.push(path);
+        if combined.is_dir() {
+            return Some(combined);
+        }
+    }
+    None
+}
+
 fn is_home_dir(path: &Path) -> bool {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .is_some_and(|home| path == home)
+    cross_platform_home().is_some_and(|home| path == home)
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,10 +194,25 @@ fn schedule_update_check() {
         return;
     }
 
-    let Some(setup) = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("qartez-setup")))
-        .filter(|p| p.is_file())
+let Some(setup) = std::env::current_exe()
+    .ok()
+    .and_then(|p| p.parent().map(|d| {
+        let bare = d.join("qartez-setup");
+        if bare.is_file() {
+            Some(bare)
+        } else if cfg!(windows) {
+            // On Windows, try with .exe suffix
+            let with_exe = d.join("qartez-setup.exe");
+            if with_exe.is_file() {
+                Some(with_exe)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }))
+    .flatten()
     else {
         return;
     };
@@ -213,13 +228,37 @@ fn schedule_update_check() {
     });
 }
 
+/// Cross-platform home directory lookup.
+/// Checks HOME (Unix), USERPROFILE (Windows), HOMEDRIVE+HOMEPATH (Windows),
+/// then falls back to current directory.
+fn cross_platform_home() -> Option<PathBuf> {
+    // Try HOME (Unix)
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(home));
+    }
+    // Try USERPROFILE (Windows)
+    if let Some(profile) = std::env::var_os("USERPROFILE") {
+        return Some(PathBuf::from(profile));
+    }
+    // Try HOMEDRIVE+HOMEPATH (Windows fallback)
+    if let (Some(drive), Some(path)) = (
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+    ) {
+        let mut combined = PathBuf::from(drive);
+        combined.push(path);
+        if combined.is_dir() {
+            return Some(combined);
+        }
+    }
+    None
+}
+
 fn update_cache_is_fresh() -> bool {
-    let Some(home) = std::env::var_os("HOME") else {
+    let Some(home) = cross_platform_home() else {
         return false;
     };
-    let cache = PathBuf::from(home)
-        .join(".qartez")
-        .join("last-update-check");
+    let cache = home.join(".qartez").join("last-update-check");
     let Ok(meta) = std::fs::metadata(&cache) else {
         return false;
     };

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -178,19 +178,33 @@ pub fn detect_all_toolchains(project_root: &Path) -> Vec<DetectedToolchain> {
     toolchains
 }
 
-/// Checks whether a binary is available on PATH.
+/// Checks whether a binary is available on PATH using pure Rust PATH search.
+/// Works on both Unix and Windows without shelling out to `which`.
 pub fn binary_available(name: &str) -> bool {
     // Skip path-relative binaries like ./gradlew - they are project-local.
     if name.starts_with('.') || name.contains('/') {
         return true;
     }
-    Command::new("which")
-        .arg(name)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    let path_var = match std::env::var_os("PATH") {
+        Some(p) => p,
+        None => return false,
+    };
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return true;
+        }
+        // On Windows, also try with common executable extensions
+        if cfg!(windows) {
+            for ext in &["exe", "cmd", "bat", "com"] {
+                let with_ext = dir.join(format!("{}.{}", name, ext));
+                if with_ext.is_file() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn pubspec_uses_flutter(pubspec: &str) -> bool {

--- a/tests/test-install.ps1
+++ b/tests/test-install.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+function Step($name) { Write-Host "==> $name" -ForegroundColor Cyan }
+
+$repo = Split-Path -Parent $PSScriptRoot
+$install = Join-Path $repo 'install.ps1'
+
+Step 'Validate install.ps1 presence'
+if (-not (Test-Path -Path $install -PathType Leaf)) {
+    throw "install.ps1 missing at $install"
+}
+
+Step 'Dry-run installer'
+& powershell -ExecutionPolicy Bypass -File $install -DryRun -SkipSetup
+if ($LASTEXITCODE -ne 0) {
+    throw "install.ps1 dry-run failed with code $LASTEXITCODE"
+}
+
+Step 'PowerShell installer checks passed'

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -27,11 +27,20 @@ section() { printf "\n${BLUE}--- %s ---${NC}\n" "$1"; }
 section "File integrity"
 # ============================================================
 
+INSTALL_PS1="$PROJECT_DIR/install.ps1"
+
 # 1. install.sh exists and is executable
 if [ -x "$INSTALL_SH" ]; then
     pass "install.sh is executable"
 else
     fail "install.sh is not executable (chmod +x install.sh)"
+fi
+
+# 1b. install.ps1 exists for native Windows install
+if [ -f "$INSTALL_PS1" ]; then
+    pass "install.ps1 exists (native Windows installer)"
+else
+    fail "install.ps1 missing (native Windows installer required)"
 fi
 
 # 2. Shebang is #!/bin/sh (not bash)
@@ -54,6 +63,8 @@ if command -v shellcheck >/dev/null 2>&1; then
     SC_OUT=$(shellcheck -s sh "$INSTALL_SH" 2>&1) || true
     if [ -z "$SC_OUT" ]; then
         pass "shellcheck clean (POSIX sh)"
+    elif echo "$SC_OUT" | grep -q 'openBinaryFile: does not exist'; then
+        skip "shellcheck unavailable for current path format"
     else
         fail "shellcheck issues: $SC_OUT"
     fi
@@ -141,6 +152,24 @@ check_error_path "cargo post-install check" "cargo not found.*after"
 check_error_path "binary not found"       "Binary not found"
 check_error_path "PATH warning"           "not on your PATH"
 check_error_path "PATH fix suggestion"    'export PATH='
+
+# Windows installer static checks
+check_ps1_path() {
+    LABEL="$1"; PATTERN="$2"
+    if grep -Fq "$PATTERN" "$INSTALL_PS1" 2>/dev/null; then
+        pass "install.ps1: $LABEL"
+    else
+        fail "install.ps1 missing: $LABEL"
+    fi
+}
+
+check_ps1_path "supports interactive flag" 'Interactive'
+check_ps1_path "supports skip-setup flag" 'SkipSetup'
+check_ps1_path "installs to LOCALAPPDATA" 'LOCALAPPDATA'
+check_ps1_path "adds install dir to user PATH" "SetEnvironmentVariable('PATH'"
+check_ps1_path "builds release binaries" "@('build', '--release')"
+check_ps1_path "installs qartez binaries" "foreach (\$bin in @('qartez-mcp', 'qartez-guard', 'qartez-setup'))"
+check_ps1_path "adds .exe suffix for installed binaries" "\$bin + '.exe'"
 
 # ============================================================
 section "Download safety"

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1449,11 +1449,12 @@ mod guard_binary {
     fn denies_hot_file_without_ack() {
         let (dir, _db, hub) = indexed_project();
         let abs = dir.path().join(&hub);
-        let payload = format!(
-            r#"{{"tool_name":"Edit","tool_input":{{"file_path":"{}"}},"cwd":"{}"}}"#,
-            abs.display(),
-            dir.path().display()
-        );
+        let payload = serde_json::json!({
+            "tool_name": "Edit",
+            "tool_input": {"file_path": abs},
+            "cwd": dir.path(),
+        })
+        .to_string();
         // Thresholds set low so a 2-importer fixture trips the guard
         // deterministically, independent of actual PageRank values.
         let out = run_guard(
@@ -1476,11 +1477,12 @@ mod guard_binary {
         guard::touch_ack(dir.path(), &hub);
 
         let abs = dir.path().join(&hub);
-        let payload = format!(
-            r#"{{"tool_name":"Edit","tool_input":{{"file_path":"{}"}},"cwd":"{}"}}"#,
-            abs.display(),
-            dir.path().display()
-        );
+        let payload = serde_json::json!({
+            "tool_name": "Edit",
+            "tool_input": {"file_path": abs},
+            "cwd": dir.path(),
+        })
+        .to_string();
         let out = run_guard(
             dir.path(),
             &payload,
@@ -1496,11 +1498,12 @@ mod guard_binary {
     fn allows_non_edit_tools() {
         let (dir, _db, hub) = indexed_project();
         let abs = dir.path().join(&hub);
-        let payload = format!(
-            r#"{{"tool_name":"Bash","tool_input":{{"command":"ls {}"}},"cwd":"{}"}}"#,
-            abs.display(),
-            dir.path().display()
-        );
+        let payload = serde_json::json!({
+            "tool_name": "Bash",
+            "tool_input": {"command": format!("ls {}", abs.display())},
+            "cwd": dir.path(),
+        })
+        .to_string();
         let out = run_guard(
             dir.path(),
             &payload,
@@ -1513,11 +1516,12 @@ mod guard_binary {
     fn allows_unindexed_file() {
         let (dir, _db, _hub) = indexed_project();
         let abs = dir.path().join("src/new_file.rs");
-        let payload = format!(
-            r#"{{"tool_name":"Write","tool_input":{{"file_path":"{}"}},"cwd":"{}"}}"#,
-            abs.display(),
-            dir.path().display()
-        );
+        let payload = serde_json::json!({
+            "tool_name": "Write",
+            "tool_input": {"file_path": abs},
+            "cwd": dir.path(),
+        })
+        .to_string();
         let out = run_guard(
             dir.path(),
             &payload,


### PR DESCRIPTION
## Summary
- Add native Windows installer support with `install.ps1` and Makefile targets (`deploy-windows`, `setup-windows`, `install-windows`), plus README quickstart updates for PowerShell installation.
- Complete hook/runtime portability by removing setup-time dependency on legacy shell hook wrappers and ensuring binary-based hook commands remain functional after rebasing onto current `origin/main`.
- Add PR validation coverage for cross-platform installer behavior with a GitHub Actions matrix workflow and a Windows installer smoke test (`tests/test-install.ps1`).