### PR TITLE
feat(skill): improve qartez guard contracts and host parity

### DIFF
--- a/scripts/AGENTS.md.snippet
+++ b/scripts/AGENTS.md.snippet
@@ -32,6 +32,14 @@ Qartez is an AST-based code intelligence MCP server. Use its tools instead of bu
 4. **`qartez_impact`** BEFORE modifying any heavily-imported file
 5. **`qartez_context`** before multi-file changes to surface files you might miss
 
+### Denial recovery
+
+When built-in code tools are blocked by qartez guard, parse the JSON payload in the denial reason and retry with the listed `replacement` tool(s).
+
+- `reason_code=SOURCE_CODE_REQUIRES_QARTEZ` → retry with replacement
+- `reason_code=INDEX_NOT_READY` → wait for READY state in `.qartez/status.json`
+- `type=RISK_ACK_REQUIRED` → run `qartez_impact`, then retry edit
+
 ### Modification guard
 
 Before editing a file that is central to the codebase, call `qartez_impact` with `file_path=<the file>` first. A file is considered load-bearing when its PageRank >= 0.05 or its transitive blast radius >= 10. Editing without checking impact risks breaking downstream dependents.

--- a/scripts/CLAUDE.md.snippet
+++ b/scripts/CLAUDE.md.snippet
@@ -4,4 +4,5 @@
 Before code exploration, invoke the `qartez` skill for workflows and tool reference.
 Before editing a load-bearing file, call `qartez_impact` first.
 Use `Glob`/`Grep`/`Read` only for non-code content.
+If a built-in code tool is denied, parse the embedded qartez JSON payload and retry using `replacement` tools.
 <!-- /qartez-mcp-instructions -->

--- a/scripts/instructions.md
+++ b/scripts/instructions.md
@@ -31,6 +31,15 @@ Qartez is an AST-based code intelligence MCP server. Use its tools instead of bu
 4. **`qartez_impact`** BEFORE modifying any heavily-imported file
 5. **`qartez_context`** before multi-file changes to surface files you might miss
 
+### Denial recovery protocol
+
+Guards emit a machine-readable JSON payload alongside denial messages.
+
+1. Parse payload field `qartez.replacement`.
+2. Retry immediately with replacement qartez tool(s).
+3. If `reason_code` is `INDEX_NOT_READY`, wait until `.qartez/status.json` shows `READY`.
+4. If payload type is `RISK_ACK_REQUIRED`, call `qartez_impact` for the target file, then retry edit.
+
 ### Modification guard
 
 Before editing a file that is central to the codebase, call `qartez_impact` with `file_path=<the file>` first. A file is considered load-bearing when its PageRank >= 0.05 or its transitive blast radius >= 10. Editing without checking impact risks breaking downstream dependents.

--- a/scripts/opencode-plugin.ts
+++ b/scripts/opencode-plugin.ts
@@ -1,41 +1,112 @@
 // Qartez guard plugin for OpenCode.
-//
-// Two guards in one plugin:
-// 1. Read guard: blocks built-in `read` on source files, redirects to qartez_read.
-// 2. Edit guard: blocks `edit` on high-PageRank / high-blast-radius files
-//    until the agent runs qartez_impact first (same behavior as
-//    the qartez-guard binary for Claude Code).
-//
-// Install: copy to .opencode/plugin/qartez-guard.ts
-// The plugin activates only when .qartez/index.db exists in the project root.
+// Emits machine-readable denial payloads and enforces built-in→qartez routing.
 
 import type { Plugin } from "@opencode-ai/plugin";
-import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { join, relative, isAbsolute } from "path";
 import { execSync } from "child_process";
 
+type GuardState = "READY" | "INDEXING" | "UNAVAILABLE" | "STALE";
+type GuardPayloadType = "DENIED_BUILTIN_CODE_TOOL" | "RISK_ACK_REQUIRED";
+
 const CODE_EXTS = new Set([
-  "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "kt",
-  "swift", "c", "cpp", "h", "hpp", "cs", "rb", "php", "scala",
-  "zig", "lua", "dart", "ex", "exs", "erl", "hrl", "hs",
-  "ml", "mli", "vue", "svelte",
+  "ts", "tsx", "js", "jsx", "mjs", "cjs", "rs", "go", "py", "rb", "java", "kt",
+  "swift", "c", "cc", "cpp", "h", "hpp", "cs", "fs", "elm", "hs", "vue", "svelte",
+  "sh", "bash",
 ]);
 
 const PAGERANK_MIN = parseFloat(process.env.QARTEZ_GUARD_PAGERANK_MIN ?? "0.05");
 const BLAST_MIN = parseInt(process.env.QARTEZ_GUARD_BLAST_MIN ?? "10", 10);
-const ACK_TTL_SECS = parseInt(process.env.QARTEZ_GUARD_ACK_TTL_SECS ?? "600", 10);
+const ACK_TTL_SECS = parseInt(process.env.QARTEZ_ACK_TTL_SECS ?? process.env.QARTEZ_GUARD_ACK_TTL_SECS ?? "600", 10);
+
+function resolvePath(projectRoot: string, maybePath: string): string {
+  if (isAbsolute(maybePath)) return maybePath;
+  return join(projectRoot, maybePath);
+}
+
+function buildPaths(projectRoot: string) {
+  const indexPath = resolvePath(projectRoot, process.env.QARTEZ_INDEX_PATH ?? ".qartez");
+  const statusPath = resolvePath(projectRoot, process.env.QARTEZ_STATUS_PATH ?? join(indexPath, "status.json"));
+  const dbPath = join(indexPath, "index.db");
+  return { indexPath, statusPath, dbPath };
+}
+
+function readStatusState(statusPath: string): GuardState {
+  try {
+    const raw = readFileSync(statusPath, "utf-8");
+    const parsed = JSON.parse(raw) as { state?: string };
+    const state = parsed.state ?? "READY";
+    if (state === "INDEXING") return "INDEXING";
+    if (state === "UNAVAILABLE") return "UNAVAILABLE";
+    if (state === "STALE") return "STALE";
+    return "READY";
+  } catch {
+    return "READY";
+  }
+}
 
 function isCodeFile(filePath: string): boolean {
   const ext = filePath.split(".").pop()?.toLowerCase();
   return ext !== undefined && CODE_EXTS.has(ext);
 }
 
+function getPathArg(args: Record<string, unknown> | undefined): string | undefined {
+  if (!args) return undefined;
+  const candidate = (args.filePath ?? args.file_path ?? args.path) as string | undefined;
+  return candidate && candidate.length > 0 ? candidate : undefined;
+}
+
+function denialMessage(human: string, payload: Record<string, unknown>): string {
+  return `${human}\n\nQartez denial payload:\n${JSON.stringify(payload)}`;
+}
+
+function emitPayloadError(
+  human: string,
+  payloadType: GuardPayloadType,
+  body: Record<string, unknown>
+): never {
+  throw new Error(denialMessage(human, { qartez: { type: payloadType, ...body } }));
+}
+
+function emitBuiltinDenial(
+  toolAttempted: string,
+  replacement: string[],
+  reasonCode: "SOURCE_CODE_REQUIRES_QARTEZ" | "INDEX_NOT_READY",
+  retryable: boolean,
+  state: GuardState,
+  filePath?: string
+): never {
+  const body: Record<string, unknown> = {
+    tool_attempted: toolAttempted,
+    replacement,
+    reason_code: reasonCode,
+    retryable,
+    state,
+  };
+  if (filePath) body.file_path = filePath;
+
+  const human = reasonCode === "INDEX_NOT_READY"
+    ? `Qartez index is currently ${state}. Wait for READY before code-tool routing.`
+    : `Built-in ${toolAttempted} on source code is denied. Retry with ${replacement.join(" or ")}.`;
+
+  emitPayloadError(human, "DENIED_BUILTIN_CODE_TOOL", body);
+}
+
+function ackPath(projectRoot: string, relPath: string): string {
+  return join(projectRoot, ".qartez", "guard-acks", `${relPath}.ack`);
+}
+
+function touchAck(projectRoot: string, relPath: string): void {
+  const p = ackPath(projectRoot, relPath);
+  mkdirSync(join(projectRoot, ".qartez", "guard-acks"), { recursive: true });
+  writeFileSync(p, String(Date.now()));
+}
+
 function ackIsFresh(projectRoot: string, relPath: string): boolean {
-  const ackFile = join(projectRoot, ".qartez", "guard-acks", relPath + ".ack");
+  const p = ackPath(projectRoot, relPath);
   try {
-    const stat = statSync(ackFile);
-    const ageSecs = (Date.now() - stat.mtimeMs) / 1000;
-    return ageSecs < ACK_TTL_SECS;
+    const st = statSync(p);
+    return (Date.now() - st.mtimeMs) / 1000 < ACK_TTL_SECS;
   } catch {
     return false;
   }
@@ -49,12 +120,10 @@ interface FileInfo {
 function queryFileInfo(dbPath: string, relPath: string): FileInfo | null {
   try {
     const result = execSync(
-      `sqlite3 -json "${dbPath}" "SELECT pagerank, ` +
-      `(SELECT COUNT(*) FROM edges WHERE to_file = files.id) as blast ` +
-      `FROM files WHERE path = '${relPath.replace(/'/g, "''")}';"`,
+      `sqlite3 -json "${dbPath}" "SELECT pagerank, (SELECT COUNT(*) FROM edges WHERE to_file = files.id) as blast FROM files WHERE path = '${relPath.replace(/'/g, "''")}';"`,
       { timeout: 3000, encoding: "utf-8" }
     );
-    const rows = JSON.parse(result);
+    const rows = JSON.parse(result) as Array<{ pagerank?: number; blast?: number }>;
     if (rows.length > 0) {
       return { pagerank: rows[0].pagerank ?? 0, blast: rows[0].blast ?? 0 };
     }
@@ -64,9 +133,17 @@ function queryFileInfo(dbPath: string, relPath: string): FileInfo | null {
   return null;
 }
 
-export const QartezGuard: Plugin = async ({ app }) => {
+function isEditTool(tool: string): boolean {
+  return tool === "edit" || tool === "write" || tool === "multiedit" || tool === "patch" || tool === "str_replace_editor";
+}
+
+export const QartezGuard: Plugin = async () => {
   const projectRoot = process.cwd();
-  const dbPath = join(projectRoot, ".qartez", "index.db");
+  if (process.env.QARTEZ_GUARD_DISABLE === "1") {
+    return {};
+  }
+
+  const { statusPath, dbPath } = buildPaths(projectRoot);
   if (!existsSync(dbPath)) {
     return {};
   }
@@ -75,45 +152,59 @@ export const QartezGuard: Plugin = async ({ app }) => {
     tool: {
       execute: {
         before: async (input, output) => {
-          const filePath: string | undefined = output.args?.filePath;
-          if (!filePath) return;
+          const tool = String(input.tool ?? "").toLowerCase();
+          const filePath = getPathArg(output.args as Record<string, unknown> | undefined);
+          const state = readStatusState(statusPath);
 
-          // Guard 1: block read on source files
-          if (input.tool === "read" && isCodeFile(filePath)) {
-            throw new Error(
-              `Qartez MCP is indexed. Use qartez_read, qartez_find, or qartez_grep ` +
-              `instead of the built-in read tool for source files.`
-            );
+          if (state === "INDEXING" && (tool === "glob" || tool === "grep" || tool === "read")) {
+            emitBuiltinDenial(tool, [], "INDEX_NOT_READY", false, "INDEXING", filePath);
           }
 
-          // Guard 2: block edit on high-PageRank / high-blast files
-          if (input.tool === "edit" || input.tool === "write") {
-            if (!isCodeFile(filePath)) return;
+          if (tool === "glob") {
+            emitBuiltinDenial("glob", ["qartez_map"], "SOURCE_CODE_REQUIRES_QARTEZ", true, state, filePath);
+          }
 
-            const rel = isAbsolute(filePath)
-              ? relative(projectRoot, filePath)
-              : filePath;
+          if (tool === "grep") {
+            emitBuiltinDenial("grep", ["qartez_grep", "qartez_find"], "SOURCE_CODE_REQUIRES_QARTEZ", true, state, filePath);
+          }
 
-            if (ackIsFresh(projectRoot, rel)) return;
+          if (tool === "read" && filePath && isCodeFile(filePath)) {
+            emitBuiltinDenial("read", ["qartez_read", "qartez_outline"], "SOURCE_CODE_REQUIRES_QARTEZ", true, state, filePath);
+          }
 
-            const info = queryFileInfo(dbPath, rel);
-            if (!info) return;
+          if (!isEditTool(tool)) return;
+          if (!filePath || !isCodeFile(filePath)) return;
 
-            const prFired = info.pagerank >= PAGERANK_MIN;
-            const blastFired = info.blast >= BLAST_MIN;
+          const relPath = isAbsolute(filePath) ? relative(projectRoot, filePath) : filePath;
 
-            if (prFired || blastFired) {
-              const reasons: string[] = [];
-              if (prFired) reasons.push(`PageRank ${info.pagerank.toFixed(4)} >= ${PAGERANK_MIN}`);
-              if (blastFired) reasons.push(`blast radius ${info.blast} >= ${BLAST_MIN}`);
+          if (tool === "write" && output.args && typeof output.args === "object" && (output.args as Record<string, unknown>).qartez_ack === true) {
+            touchAck(projectRoot, relPath);
+            return;
+          }
 
-              throw new Error(
-                `Qartez modification guard: ${rel} is load-bearing (${reasons.join(", ")}). ` +
-                `Run qartez_impact with file_path="${rel}" first to review the blast radius, ` +
-                `then retry the edit.`
-              );
+          if (ackIsFresh(projectRoot, relPath)) return;
+
+          const info = queryFileInfo(dbPath, relPath);
+          if (!info) return;
+
+          const prFired = info.pagerank >= PAGERANK_MIN;
+          const blastFired = info.blast >= BLAST_MIN;
+          if (!prFired && !blastFired) return;
+
+          emitPayloadError(
+            `Qartez modification guard: ${relPath} is load-bearing. Run qartez_impact first, then retry edit.`,
+            "RISK_ACK_REQUIRED",
+            {
+              tool_attempted: tool,
+              file_path: relPath,
+              replacement: ["qartez_impact"],
+              reason_code: "LOAD_BEARING_FILE",
+              pagerank: info.pagerank,
+              blast_radius: info.blast,
+              retryable: true,
+              ack_ttl_secs: ACK_TTL_SECS,
             }
-          }
+          );
         },
       },
     },

--- a/scripts/qartez-guard.sh
+++ b/scripts/qartez-guard.sh
@@ -1,26 +1,115 @@
 #!/bin/bash
 # qartez-guard.sh - PreToolUse hook for Claude Code
-# Denies Glob/Grep when qartez MCP is indexed for the current project.
-# Forces Claude to use qartez_map/qartez_find/qartez_grep instead.
-# Falls through (allows) when .qartez/ does not exist.
+# Emits machine-readable denial payloads for built-in code tools.
 
-QARTEZ_DIR="${CLAUDE_PROJECT_DIR:-.}/.qartez"
+set -u
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+INDEX_PATH="${QARTEZ_INDEX_PATH:-$PROJECT_DIR/.qartez}"
+if [[ "$INDEX_PATH" != /* ]]; then
+  INDEX_PATH="$PROJECT_DIR/$INDEX_PATH"
+fi
+
+STATUS_PATH="${QARTEZ_STATUS_PATH:-$INDEX_PATH/status.json}"
+ACK_TTL_SECS="${QARTEZ_ACK_TTL_SECS:-600}"
+
+# Explicit global off-switch.
+if [ "${QARTEZ_GUARD_DISABLE:-0}" = "1" ]; then
+  exit 0
+fi
 
 # No qartez index = allow built-in tools
-[ ! -d "$QARTEZ_DIR" ] && exit 0
+[ ! -d "$INDEX_PATH" ] && exit 0
 
-# Qartez is available - read tool input and redirect
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+INPUT="$(cat)"
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
+FILE_PATH="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // .file_path // .filePath // empty')"
+
+read_status_state() {
+  if [ -f "$STATUS_PATH" ]; then
+    jq -r '.state // "READY"' "$STATUS_PATH" 2>/dev/null || printf 'READY'
+  else
+    printf 'READY'
+  fi
+}
+
+is_source_file() {
+  case "${1##*.}" in
+    ts|tsx|js|jsx|mjs|cjs|rs|go|py|rb|java|kt|swift|c|cc|cpp|h|hpp|cs|fs|elm|hs|vue|svelte|sh|bash)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+deny_with_payload() {
+  local human_message="$1"
+  local payload_json="$2"
+  local reason
+
+  reason="${human_message}\n\nQartez denial payload:\n${payload_json}"
+  jq -cn --arg reason "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+  exit 0
+}
+
+emit_builtin_denial() {
+  local tool_attempted="$1"
+  local replacement_json="$2"
+  local reason_code="$3"
+  local retryable="$4"
+  local state="$5"
+  local human_message="$6"
+
+  local payload
+  if [ -n "$FILE_PATH" ]; then
+    payload="$(jq -cn --arg t "$tool_attempted" --arg fp "$FILE_PATH" --argjson replacement "$replacement_json" --arg reason "$reason_code" --argjson retryable "$retryable" --arg state "$state" '{qartez:{type:"DENIED_BUILTIN_CODE_TOOL",tool_attempted:$t,file_path:$fp,replacement:$replacement,reason_code:$reason,retryable:$retryable,state:$state}}')"
+  else
+    payload="$(jq -cn --arg t "$tool_attempted" --argjson replacement "$replacement_json" --arg reason "$reason_code" --argjson retryable "$retryable" --arg state "$state" '{qartez:{type:"DENIED_BUILTIN_CODE_TOOL",tool_attempted:$t,replacement:$replacement,reason_code:$reason,retryable:$retryable,state:$state}}')"
+  fi
+
+  deny_with_payload "$human_message" "$payload"
+}
+
+emit_risk_ack_required() {
+  local human_message="$1"
+  local payload
+  payload="$(jq -cn --arg fp "$FILE_PATH" --argjson ttl "$ACK_TTL_SECS" '{qartez:{type:"RISK_ACK_REQUIRED",tool_attempted:"edit",file_path:$fp,replacement:["qartez_impact"],reason_code:"LOAD_BEARING_FILE",pagerank:null,blast_radius:null,retryable:true,ack_ttl_secs:$ttl}}')"
+  deny_with_payload "$human_message" "$payload"
+}
+
+STATE="$(read_status_state)"
+
+if [ "$STATE" = "INDEXING" ]; then
+  case "$TOOL_NAME" in
+    Glob|Grep|Read|View|cat)
+      emit_builtin_denial "$TOOL_NAME" '[]' 'INDEX_NOT_READY' 'false' 'INDEXING' 'Qartez index is currently building. Wait for READY before using code search/read tools.'
+      ;;
+  esac
+fi
 
 case "$TOOL_NAME" in
   Glob)
-    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STOP: qartez MCP is available. Use `qartez_map` for project structure or `qartez_find` to locate symbols. Use Glob ONLY for non-code file patterns (e.g., *.toml, *.json) - if so, use Bash find/ls instead."}}'
+    emit_builtin_denial "Glob" '["qartez_map"]' 'SOURCE_CODE_REQUIRES_QARTEZ' 'true' "$STATE" 'STOP: qartez MCP is available. Use qartez_map for project structure and file discovery.'
     ;;
   Grep)
-    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STOP: qartez MCP is available. Use `qartez_grep` for symbol search or `qartez_find` for definitions. Use Grep ONLY for non-symbol text search (e.g., TODO comments, string literals) - if so, use Bash grep instead."}}'
+    emit_builtin_denial "Grep" '["qartez_grep","qartez_find"]' 'SOURCE_CODE_REQUIRES_QARTEZ' 'true' "$STATE" 'STOP: qartez MCP is available. Use qartez_grep for symbol/body search or qartez_find for exact symbol definitions.'
+    ;;
+  Read|View|cat)
+    if [ -n "$FILE_PATH" ] && is_source_file "$FILE_PATH"; then
+      emit_builtin_denial "$TOOL_NAME" '["qartez_read","qartez_outline"]' 'SOURCE_CODE_REQUIRES_QARTEZ' 'true' "$STATE" 'STOP: source-code reads must use qartez_read or qartez_outline.'
+    fi
+    ;;
+  Edit|Write|MultiEdit)
+    if [ -n "$FILE_PATH" ] && is_source_file "$FILE_PATH"; then
+      emit_risk_ack_required 'Load-bearing edit requires risk acknowledgment. Run qartez_impact on the target file, then retry the edit.'
+    fi
     ;;
   *)
     exit 0
     ;;
 esac
+
+exit 0

--- a/scripts/qartez-session-start.sh
+++ b/scripts/qartez-session-start.sh
@@ -4,7 +4,15 @@
 # and no .qartez/ index exists yet. Fire-and-forget: the hook returns
 # immediately and the indexer runs detached in the background.
 
+set -u
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+INDEX_PATH="${QARTEZ_INDEX_PATH:-$PROJECT_DIR/.qartez}"
+if [[ "$INDEX_PATH" != /* ]]; then
+    INDEX_PATH="$PROJECT_DIR/$INDEX_PATH"
+fi
+STATUS_PATH="${QARTEZ_STATUS_PATH:-$INDEX_PATH/status.json}"
+STALE_THRESHOLD_SECS="${QARTEZ_STALE_THRESHOLD_SECS:-300}"
 
 # No project dir → nothing to do
 [ -z "$PROJECT_DIR" ] && exit 0
@@ -16,7 +24,7 @@ case "$PROJECT_DIR" in
 esac
 
 # Already indexed → nothing to do
-[ -d "$PROJECT_DIR/.qartez" ] && exit 0
+[ -d "$INDEX_PATH" ] && exit 0
 
 # Require at least one repo marker so we don't index random folders
 HAS_MARKER=0
@@ -42,6 +50,76 @@ if [ -z "$BINARY" ]; then
 fi
 [ -z "$BINARY" ] && exit 0
 
+mkdir -p "$INDEX_PATH" 2>/dev/null || true
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PROJECT_ROOT_REAL="$(cd "$PROJECT_DIR" 2>/dev/null && pwd)"
+
+write_status_indexing() {
+    cat > "$STATUS_PATH" <<JSON
+{
+  "schema_version": "1",
+  "state": "INDEXING",
+  "project_root": "$PROJECT_ROOT_REAL",
+  "index_version": null,
+  "languages": [],
+  "file_count": 0,
+  "is_stale": false,
+  "stale_threshold_secs": $STALE_THRESHOLD_SECS,
+  "last_error": null,
+  "started_at": "$STARTED_AT",
+  "ready_at": null,
+  "progress_hint": "starting index build"
+}
+JSON
+}
+
+write_status_ready() {
+    local ready_at file_count
+    ready_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    file_count="$(find "$PROJECT_DIR" -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.rs' -o -name '*.go' -o -name '*.py' -o -name '*.java' -o -name '*.kt' -o -name '*.swift' -o -name '*.c' -o -name '*.cpp' -o -name '*.rb' -o -name '*.php' \) 2>/dev/null | wc -l | tr -d ' ')"
+    [ -z "$file_count" ] && file_count=0
+
+    cat > "$STATUS_PATH" <<JSON
+{
+  "schema_version": "1",
+  "state": "READY",
+  "project_root": "$PROJECT_ROOT_REAL",
+  "index_version": "$ready_at",
+  "languages": [],
+  "file_count": $file_count,
+  "is_stale": false,
+  "stale_threshold_secs": $STALE_THRESHOLD_SECS,
+  "last_error": null,
+  "started_at": "$STARTED_AT",
+  "ready_at": "$ready_at",
+  "progress_hint": null
+}
+JSON
+}
+
+write_status_unavailable() {
+    local error_message="$1"
+    cat > "$STATUS_PATH" <<JSON
+{
+  "schema_version": "1",
+  "state": "UNAVAILABLE",
+  "project_root": "$PROJECT_ROOT_REAL",
+  "index_version": null,
+  "languages": [],
+  "file_count": 0,
+  "is_stale": false,
+  "stale_threshold_secs": $STALE_THRESHOLD_SECS,
+  "last_error": "$error_message",
+  "started_at": "$STARTED_AT",
+  "ready_at": null,
+  "progress_hint": null
+}
+JSON
+}
+
+write_status_indexing
+
 # Fire-and-forget background reindex. nohup + setsid (when available) detaches
 # the process so it survives hook completion. Output is routed to a log so the
 # user can inspect failures.
@@ -49,11 +127,20 @@ LOG_DIR="$HOME/.cache/qartez-mcp"
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 LOG_FILE="$LOG_DIR/session-index.log"
 
-if command -v setsid >/dev/null 2>&1; then
-    setsid nohup "$BINARY" --root "$PROJECT_DIR" --reindex >>"$LOG_FILE" 2>&1 < /dev/null &
-else
-    nohup "$BINARY" --root "$PROJECT_DIR" --reindex >>"$LOG_FILE" 2>&1 < /dev/null &
-fi
+(
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$BINARY" --root "$PROJECT_DIR" --reindex >>"$LOG_FILE" 2>&1 < /dev/null
+    else
+        "$BINARY" --root "$PROJECT_DIR" --reindex >>"$LOG_FILE" 2>&1 < /dev/null
+    fi
+    exit_code=$?
+    if [ "$exit_code" -eq 0 ]; then
+        write_status_ready
+    else
+        write_status_unavailable "index build failed (exit $exit_code)"
+    fi
+) >/dev/null 2>&1 &
+
 disown 2>/dev/null || true
 
 exit 0

--- a/scripts/skill/SKILL.md
+++ b/scripts/skill/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: qartez
 description: >-
-  Orchestrate Qartez code intelligence MCP tools for code exploration, architecture
-  analysis, refactoring, debugging, code review, impact analysis, and onboarding.
-  Use this skill whenever performing multi-step code exploration with qartez tools,
-  reviewing files for blast radius, tracing call hierarchies, finding dead code,
-  detecting duplicates, checking architecture boundaries, or planning refactors.
-  Also trigger on: 'review this file', 'find dead code', 'what calls this function',
-  'show architecture', 'check boundaries', 'find duplicates', 'impact analysis',
-  'rename symbol', 'move function', 'onboard me', 'hotspots', 'code review',
-  'dependency graph', 'blast radius', architecture overview, debugging call chains,
-  or when about to modify a load-bearing file. Even if the user does not mention
-  qartez explicitly, trigger when the task involves semantic code analysis beyond
-  simple text search.
+  Semantic code intelligence skill for qartez MCP. Use qartez tools for code
+  exploration, impact analysis, and guarded refactors; treat built-in code-tool
+  denials as routing signals and recover via qartez replacements.
 allowed-tools:
   - mcp__qartez__qartez_map
   - mcp__qartez__qartez_find
@@ -40,111 +31,139 @@ allowed-tools:
   - mcp__qartez__qartez_hierarchy
 ---
 
-# Qartez Code Intelligence Skill
+# Qartez — Semantic Code Intelligence Skill
 
-## Overview
+Qartez provides semantic, graph-aware code intelligence for any repository. It replaces naive file-system tools (glob, grep, read) with structured analysis grounded in a pre-built language-aware index.
 
-Qartez is an AST-based code intelligence MCP server that provides semantic understanding of codebases. It maintains a pre-computed index of symbols, dependencies, call graphs, and git history, making queries fast and token-efficient.
+---
 
-Use Qartez tools instead of built-in file tools for all code exploration. The index operates on parsed AST nodes rather than raw text, so results are structurally accurate: a symbol search returns definitions, not string matches in comments or variable names that happen to contain the substring.
+## 1. When Qartez Is Authoritative
 
-## Tool Mapping
+Use qartez for **all** code-related exploration and analysis work.
 
-Replace built-in file tools with Qartez equivalents:
+Use built-in tools only for non-code content or when qartez cannot handle the request.
 
-| Instead of | Use | When |
-|---|---|---|
-| Glob / find | `qartez_map` | Understanding project structure, finding files |
-| Grep / rg | `qartez_grep` | Searching for symbols, types, functions |
-| Grep / rg | `qartez_find` | Looking up a specific symbol definition |
-| Read / cat | `qartez_read` | Reading symbol source code with context |
+| Built-in intent | Qartez replacement |
+|---|---|
+| `glob` / `ls` / find | `qartez_map` |
+| `grep` / `rg` | `qartez_grep` or `qartez_find` |
+| `read` / `cat` on source | `qartez_read` |
+| outline/API surface read | `qartez_outline` |
+| dependency inspection | `qartez_deps` |
+| call chain tracing | `qartez_calls` / `qartez_refs` |
 
-Beyond these four replacements, Qartez provides 20+ additional tools for analysis, risk assessment, and refactoring. See `references/tools.md` for the complete reference.
+---
 
-## Workflows by Task Type
+## 2. Runtime States
 
-Each workflow below lists tools in the order you should call them and explains why each step matters.
+Read `.qartez/status.json` first when available.
 
-### Explore a New Codebase
+| State | Required behavior |
+|---|---|
+| `READY` | Use qartez-first workflow normally |
+| `INDEXING` | Use `qartez_map`; defer symbol/code queries |
+| `UNAVAILABLE` | Report capability mismatch; do not silently continue |
+| `CAPABILITY_MISMATCH` | Report immediately to parent/orchestrator |
+| `STALE` | Proceed with warning |
+| `RISK_ACK_REQUIRED` | Call `qartez_impact`, then retry edit |
 
-Goal: Build a mental model of the project before making any changes.
+---
 
-1. **`qartez_map`** - Get the project skeleton. This shows directory structure ranked by importance (PageRank), so you immediately know which files are central.
-2. **`qartez_stats`** - Understand the scale: languages used, lines of code, symbol counts. This sets expectations for complexity.
-3. **`qartez_outline`** on 2-3 top-ranked files - Read the symbol tables of key files without loading full source. This reveals the project's core abstractions.
-4. **`qartez_wiki`** - Generate an architecture overview via community detection. This groups files into logical modules and explains how they relate.
+## 3. Denied-tool Recovery Protocol
 
-### Find and Understand a Symbol
+A denied built-in code tool call is a **routing signal**, not completion.
 
-Goal: Locate a symbol definition and understand how it fits into the codebase.
+Guards emit JSON payloads. Parse `replacement` and retry immediately.
 
-1. **`qartez_find`** with the symbol name - Jump directly to the definition. Unlike text grep, this resolves to the AST node, giving you the exact file and line.
-2. **`qartez_read`** - Read the source with semantic context. This includes surrounding code that helps you understand the symbol's role.
-3. **`qartez_refs`** - Find every usage across the codebase. This tells you how widely the symbol is consumed and in what patterns.
-4. **`qartez_calls`** - Trace the call hierarchy. See what the symbol calls (callees) and what calls it (callers) to understand its position in execution flow.
+```json
+{
+  "qartez": {
+    "type": "DENIED_BUILTIN_CODE_TOOL",
+    "tool_attempted": "read",
+    "replacement": ["qartez_read", "qartez_outline"],
+    "reason_code": "SOURCE_CODE_REQUIRES_QARTEZ",
+    "retryable": true,
+    "state": "READY"
+  }
+}
+```
 
-### Review a File Before Editing
+If `reason_code` is `INDEX_NOT_READY`, wait until READY and retry.
 
-Goal: Understand a file's role, risk level, and coupling before making changes.
+---
 
-1. **`qartez_outline`** - Get the symbol table first. This is cheaper than reading full source and shows you the file's API surface.
-2. **`qartez_impact`** - Check the blast radius. This reveals how many files depend on this file transitively, so you know the scope of potential breakage.
-3. **`qartez_cochange`** - See which files historically change together with this one. If you modify this file, you likely need to update its co-change partners too.
-4. **`qartez_deps`** - View the dependency edges (imports and exports). This shows the file's direct connections to the rest of the codebase.
+## 4. Subagent / Delegated Sessions
 
-### Debug a Bug
+For delegated sessions (e.g., `<!-- OMO_INTERNAL_INITIATOR -->`):
 
-Goal: Trace execution flow to find where a bug originates.
+1. Start with qartez tools directly.
+2. Treat denials as routing signals and recover via replacement tool.
+3. If qartez tools are visible but execution fails, report `CAPABILITY_MISMATCH`.
+4. End with the execution footer template below.
 
-1. **`qartez_find`** with the relevant symbol (error message, function name, type) - Locate the starting point.
-2. **`qartez_read`** - Read the implementation to understand the current logic.
-3. **`qartez_calls`** - Trace the call chain. Walk callers upward to find what triggers the buggy path, or walk callees downward to find where the logic goes wrong.
-4. **`qartez_refs`** - Check all usages to see if other call sites handle edge cases differently, which can reveal the intended behavior.
+---
 
-### Refactor Safely
+## 5. Operating Modes
 
-Goal: Restructure code without breaking dependents.
+### Explore mode (read-only)
 
-1. **`qartez_impact`** - Start by measuring the blast radius. If the target symbol or file has high PageRank or many transitive dependents, proceed with extra caution.
-2. **`qartez_context`** - Surface all files related to the planned change. This catches files you might otherwise miss that reference the target indirectly.
-3. **`qartez_hotspots`** - Identify the highest-risk areas (complexity x coupling x churn). Focus refactoring effort where it will have the most impact.
-4. **`qartez_clones`** - Detect duplicate code via AST hashing. If the code you plan to refactor has clones elsewhere, consider consolidating them in the same pass.
-5. **`qartez_rename`** / **`qartez_move`** - Execute the refactoring. These tools update all references across the codebase automatically.
+Primary tools: `qartez_map`, `qartez_find`, `qartez_grep`, `qartez_read`, `qartez_outline`, `qartez_refs`, `qartez_calls`, `qartez_deps`, `qartez_context`, `qartez_stats`.
 
-### Architecture Overview
+### Change mode (edit-authorized)
 
-Goal: Produce a high-level understanding of the system's structure and health.
+Risk tools and transforms: `qartez_impact`, `qartez_diff_impact`, `qartez_cochange`, `qartez_unused`, `qartez_rename`, `qartez_move`, `qartez_rename_file`.
 
-1. **`qartez_map`** - Get the ranked file tree. High-PageRank files form the architectural backbone.
-2. **`qartez_stats`** - Quantify the project: languages, size, symbol density.
-3. **`qartez_hotspots`** - Find where risk concentrates. Files with high complexity, high coupling, and frequent churn are architectural pain points.
-4. **`qartez_wiki`** - Generate a full architecture document using community detection to identify logical modules.
-5. **`qartez_boundaries`** - Check whether the codebase respects its declared architecture rules (if `.qartez/boundaries.toml` exists).
+---
 
-### Find Dead Code
+## 6. Workflows
 
-Goal: Identify unused exports that can be safely removed.
+- Explore: `qartez_map → qartez_find → qartez_outline → qartez_read → qartez_refs/calls → qartez_deps`
+- Debug: `qartez_find → qartez_calls → qartez_refs → qartez_read → qartez_context → qartez_deps`
+- Review before edit: `qartez_outline → qartez_impact → qartez_cochange → qartez_deps → qartez_context`
+- Refactor: `qartez_find → qartez_refs → qartez_impact → qartez_deps → qartez_rename/move → re-verify refs`
+- Pre-merge: `qartez_diff_impact → qartez_hotspots → qartez_cochange → qartez_boundaries → qartez_context`
 
-1. **`qartez_unused`** - Scan for exported symbols with zero internal consumers. This is the primary dead-code detection tool.
-2. **`qartez_refs`** on each candidate - Verify that the symbol truly has zero usages. Some symbols may be used dynamically or via external consumers that the index does not track.
+---
 
-### Pre-merge Check
+## 7. Modification Guard
 
-Goal: Assess the risk of a set of changes before merging.
+If edit is blocked on a load-bearing file:
 
-1. **`qartez_diff_impact`** - Analyze the current diff to see which files and symbols are affected and their blast radii.
-2. **`qartez_context`** - Surface related files that the diff might have missed. If context reveals untouched files that should have been updated, flag them.
-3. **`qartez_boundaries`** - Verify the changes do not violate architecture boundary rules.
+1. Call `qartez_impact` with `file_path`.
+2. Review blast radius.
+3. Retry edit (ack window defaults to 10 minutes).
 
-## Modification Guard
+---
 
-A PreToolUse hook (`qartez-guard`) blocks Edit, Write, and MultiEdit on load-bearing files, those with PageRank >= 0.05 or transitive blast radius >= 10. When blocked, the error message tells you exactly which thresholds fired.
+## 8. Subagent Execution Footer
 
-To acknowledge the risk and proceed: call `qartez_impact` with `file_path=<the file>`. This grants edit access for 10 minutes.
+Delegated sessions should end with:
 
-For configuration details, environment variable overrides, and how to disable the guard, see `references/guard.md`.
+```md
+<!-- QARTEZ_EXECUTION_REPORT
+State: <READY|INDEXING|CAPABILITY_MISMATCH|UNAVAILABLE|STALE>
+Tools_used: <comma-separated list>
+Builtin_denials: <count by type or none>
+Recovery_actions: <what was retried or none>
+Change_mode_used: <yes|no>
+Risk_ack_issued: <yes, file list|no>
+Residual_uncertainty: <text or none>
+Missing_capability: <text or none>
+-->
+```
 
-## Reference Files
+---
 
-- **`references/tools.md`** - Complete reference for all 24 tools with parameters, return values, and trigger phrases
-- **`references/guard.md`** - Modification guard configuration, thresholds, and environment variable overrides
+## 9. References
+
+- `references/runtime-contract.md`
+- `references/subagent-contract.md`
+- `references/host-matrix.md`
+- `references/confidence-model.md`
+- `references/doctrine-explore.md`
+- `references/doctrine-debug.md`
+- `references/doctrine-review.md`
+- `references/doctrine-refactor.md`
+- `references/doctrine-premerge.md`
+- `references/tools.md`
+- `references/guard.md`

--- a/scripts/skill/references/confidence-model.md
+++ b/scripts/skill/references/confidence-model.md
@@ -1,0 +1,29 @@
+# Qartez Confidence Model
+
+Defines confidence levels for qartez outputs and required caveat labeling.
+
+## Levels
+
+| Level | Meaning | Typical tools |
+|---|---|---|
+| Exact | Derived directly from indexed symbols/edges | `qartez_find`, `qartez_map`, `qartez_read`, `qartez_outline`, `qartez_stats` |
+| Strong | High-confidence static analysis with known dynamic blind spots | `qartez_refs`, `qartez_calls`, `qartez_deps`, `qartez_impact`, `qartez_context` |
+| Heuristic | Best-effort; requires manual verification | `qartez_unused`, `qartez_clones` |
+| Historical Correlation | Based on git co-occurrence/churn, not causality | `qartez_cochange`, `qartez_hotspots`, `qartez_trend` |
+| Inferred | Structural inference/modeling | `qartez_wiki`, boundary suggestions |
+
+## Blind spots
+
+- Dynamic dispatch and reflection
+- Runtime string-based imports
+- External consumers outside the indexed repository
+
+## Output labeling standard
+
+Use labels when presenting non-exact outputs:
+
+```text
+[CONFIDENCE: HEURISTIC] ...
+[CONFIDENCE: HISTORICAL] ...
+[CONFIDENCE: INFERRED] ...
+```

--- a/scripts/skill/references/doctrine-debug.md
+++ b/scripts/skill/references/doctrine-debug.md
@@ -1,0 +1,17 @@
+# Doctrine: Debug
+
+Goal: Trace from symptom to root cause using semantic graph traversal.
+
+## Sequence
+
+1. `qartez_find`
+2. `qartez_calls`
+3. `qartez_refs`
+4. `qartez_read`
+5. `qartez_context`
+6. `qartez_deps`
+
+## Output standard
+
+- Show step-by-step trace with file/symbol anchors
+- Mark inferred transitions explicitly

--- a/scripts/skill/references/doctrine-explore.md
+++ b/scripts/skill/references/doctrine-explore.md
@@ -1,0 +1,18 @@
+# Doctrine: Explore
+
+Goal: Build a reliable model of the code area before proposing changes.
+
+## Sequence
+
+1. `qartez_map`
+2. `qartez_find`
+3. `qartez_outline`
+4. `qartez_read`
+5. `qartez_refs` / `qartez_calls`
+6. `qartez_deps`
+
+## Output standard
+
+- Cite exact file paths
+- Separate exact findings from inferred conclusions
+- Include uncertainty when dynamic behavior is involved

--- a/scripts/skill/references/doctrine-premerge.md
+++ b/scripts/skill/references/doctrine-premerge.md
@@ -1,0 +1,28 @@
+# Doctrine: Pre-merge Risk Assessment
+
+Goal: Produce a risk-labeled merge recommendation from semantic impact signals.
+
+## Sequence
+
+1. `qartez_diff_impact`
+2. `qartez_hotspots`
+3. `qartez_cochange`
+4. `qartez_boundaries`
+5. `qartez_context` (highest blast-radius files)
+6. `qartez_refs` (key changed symbols)
+
+## Report template
+
+```text
+PRE-MERGE RISK REPORT
+Changed files: <n>
+Overall blast radius: <n>
+Risk: LOW | MEDIUM | HIGH | CRITICAL
+
+Hotspots touched: ...
+Missing co-change candidates: ...
+Boundary violations: ...
+Unaccounted consumers: ...
+
+Recommendation: SAFE TO MERGE | REVIEW REQUIRED | BLOCK
+```

--- a/scripts/skill/references/doctrine-refactor.md
+++ b/scripts/skill/references/doctrine-refactor.md
@@ -1,0 +1,25 @@
+# Doctrine: Refactor
+
+Goal: Execute semantically safe refactors with full verification.
+
+## Phase 1 — Understand
+
+1. `qartez_find`
+2. `qartez_refs`
+3. `qartez_impact`
+4. `qartez_cochange`
+5. `qartez_deps`
+6. `qartez_boundaries`
+
+## Phase 2 — Execute
+
+7. `qartez_rename` / `qartez_move` / `qartez_rename_file`
+
+## Phase 3 — Verify
+
+8. `qartez_refs` (new symbol/path)
+9. `qartez_find` (old symbol/path should be absent)
+
+## Dead-code branch
+
+Use `qartez_unused` then verify each candidate with `qartez_refs` before deletion.

--- a/scripts/skill/references/doctrine-review.md
+++ b/scripts/skill/references/doctrine-review.md
@@ -1,0 +1,16 @@
+# Doctrine: Review Before Edit
+
+Goal: Assess risk and required context before touching code.
+
+## Sequence
+
+1. `qartez_outline`
+2. `qartez_impact`
+3. `qartez_cochange`
+4. `qartez_deps`
+5. `qartez_context`
+6. `qartez_refs`
+
+## Decision gate
+
+Pause if blast radius is unexpectedly high or boundary violations are likely.

--- a/scripts/skill/references/guard.md
+++ b/scripts/skill/references/guard.md
@@ -1,78 +1,81 @@
 # Modification Guard Reference
 
-## What It Does
+## Purpose
 
-The `qartez-guard` hook is a PreToolUse hook that intercepts Edit, Write, and MultiEdit tool calls. Before allowing a modification to proceed, it checks whether the target file is "load-bearing" (central to the codebase based on graph metrics). If the file exceeds the configured thresholds, the edit is blocked with an error message explaining exactly which thresholds were triggered.
+Qartez guard hooks prevent unsafe built-in code-tool usage and enforce risk acknowledgment before load-bearing edits.
 
-This prevents accidental breakage of critical files by requiring you to explicitly assess the impact before editing.
+## Denial contracts
 
-## Thresholds
+Both shell and OpenCode guards emit a machine-readable JSON payload in denial text:
 
-A file is considered load-bearing when either condition is true:
+### 1) Built-in code tool denial
 
-| Metric | Default threshold | Meaning |
+```json
+{
+  "qartez": {
+    "type": "DENIED_BUILTIN_CODE_TOOL",
+    "tool_attempted": "read",
+    "file_path": "src/server/mod.rs",
+    "replacement": ["qartez_read", "qartez_outline"],
+    "reason_code": "SOURCE_CODE_REQUIRES_QARTEZ",
+    "retryable": true,
+    "state": "READY"
+  }
+}
+```
+
+### 2) Index not ready denial
+
+```json
+{
+  "qartez": {
+    "type": "DENIED_BUILTIN_CODE_TOOL",
+    "tool_attempted": "grep",
+    "replacement": [],
+    "reason_code": "INDEX_NOT_READY",
+    "retryable": false,
+    "state": "INDEXING"
+  }
+}
+```
+
+### 3) Risk acknowledgment required
+
+```json
+{
+  "qartez": {
+    "type": "RISK_ACK_REQUIRED",
+    "tool_attempted": "edit",
+    "file_path": "src/server/mod.rs",
+    "replacement": ["qartez_impact"],
+    "reason_code": "LOAD_BEARING_FILE",
+    "pagerank": 0.12,
+    "blast_radius": 34,
+    "retryable": true,
+    "ack_ttl_secs": 600
+  }
+}
+```
+
+## Recovery behavior
+
+1. Parse payload JSON from denial.
+2. If `type=DENIED_BUILTIN_CODE_TOOL` and `retryable=true`, retry with `replacement`.
+3. If `reason_code=INDEX_NOT_READY`, wait for status `READY`.
+4. If `type=RISK_ACK_REQUIRED`, call `qartez_impact` for the file, then retry edit.
+
+## Environment variables
+
+| Variable | Default | Purpose |
 |---|---|---|
-| PageRank | >= 0.05 | The file is in the top tier of importance by dependency graph centrality |
-| Blast radius | >= 10 | At least 10 files depend on this file transitively |
+| `QARTEZ_GUARD_DISABLE` | unset | Set `1` to disable guard checks |
+| `QARTEZ_INDEX_PATH` | `.qartez` | Override index directory |
+| `QARTEZ_STATUS_PATH` | `.qartez/status.json` | Override status file path |
+| `QARTEZ_ACK_TTL_SECS` | `600` | Ack TTL for risk-ack windows |
+| `QARTEZ_GUARD_ACK_TTL_SECS` | `600` | Backward-compatible ack TTL key |
+| `QARTEZ_GUARD_PAGERANK_MIN` | `0.05` | PageRank threshold |
+| `QARTEZ_GUARD_BLAST_MIN` | `10` | Blast-radius threshold |
 
-Both thresholds are evaluated independently. If either one fires, the edit is blocked.
+## Source-file extension coverage
 
-## How to Acknowledge
-
-When the guard blocks an edit, the error message names the file and the thresholds that fired. To acknowledge the risk and proceed:
-
-```
-Call qartez_impact with file_path=<the blocked file>
-```
-
-This does two things:
-1. Shows you the full impact analysis so you understand the consequences of your edit
-2. Grants edit permission for that specific file for a limited time window
-
-After calling `qartez_impact`, retry the edit. It will succeed.
-
-## Acknowledgment TTL
-
-Each acknowledgment lasts **10 minutes** (600 seconds) by default. After the TTL expires, you must call `qartez_impact` again to re-acknowledge. This prevents stale acknowledgments from persisting across long conversations where context may have shifted.
-
-## Environment Variable Overrides
-
-Configure the guard behavior using these environment variables:
-
-| Variable | Default | Description |
-|---|---|---|
-| `QARTEZ_GUARD_PAGERANK_MIN` | `0.05` | Minimum PageRank score that triggers the guard |
-| `QARTEZ_GUARD_BLAST_MIN` | `10` | Minimum transitive blast radius that triggers the guard |
-| `QARTEZ_GUARD_ACK_TTL_SECS` | `600` | Seconds an acknowledgment remains valid |
-| `QARTEZ_GUARD_DISABLE` | `0` | Set to `1` to disable the guard entirely |
-
-### Examples
-
-Lower the PageRank threshold to catch more files:
-```bash
-export QARTEZ_GUARD_PAGERANK_MIN=0.02
-```
-
-Increase the blast radius threshold to be less strict:
-```bash
-export QARTEZ_GUARD_BLAST_MIN=20
-```
-
-Extend acknowledgment validity to 30 minutes:
-```bash
-export QARTEZ_GUARD_ACK_TTL_SECS=1800
-```
-
-Disable the guard for a session (use with caution):
-```bash
-export QARTEZ_GUARD_DISABLE=1
-```
-
-## Typical Workflow
-
-1. Attempt to edit a load-bearing file
-2. Guard blocks the edit with a message like: "Blocked: `src/core/engine.rs` has PageRank 0.12 (>= 0.05) and blast radius 34 (>= 10). Call qartez_impact to acknowledge."
-3. Call `qartez_impact file_path=src/core/engine.rs`
-4. Review the impact analysis output
-5. Retry the edit, which now succeeds
-6. If you spend more than 10 minutes before your next edit on the same file, repeat from step 3
+`ts, tsx, js, jsx, mjs, cjs, rs, go, py, rb, java, kt, swift, c, cc, cpp, h, hpp, cs, fs, elm, hs, vue, svelte, sh, bash`

--- a/scripts/skill/references/host-matrix.md
+++ b/scripts/skill/references/host-matrix.md
@@ -1,0 +1,29 @@
+# Qartez Host Matrix
+
+Current/target parity for qartez guard behavior across hosts.
+
+| Behavior | Claude hook (`qartez-guard.sh`) | OpenCode plugin (`opencode-plugin.ts`) | Target |
+|---|---|---|---|
+| Block `glob` on code tasks | Yes | Yes | Parity |
+| Block `grep` on code tasks | Yes | Yes | Parity |
+| Block `read` on source files | Yes | Yes | Parity |
+| Emit structured denial payload JSON | Yes | Yes | Parity |
+| Emit `INDEX_NOT_READY` when indexing | Yes | Yes | Parity |
+| Load-bearing edit risk ack protocol | Yes | Yes | Parity |
+| `QARTEZ_GUARD_DISABLE` support | Yes | Yes | Parity |
+| `QARTEZ_INDEX_PATH` / `QARTEZ_STATUS_PATH` support | Yes | Yes | Parity |
+| `QARTEZ_ACK_TTL_SECS` support | Yes | Yes | Parity |
+
+## Delegation compatibility
+
+| Path | Status | Notes |
+|---|---|---|
+| Claude direct session | Supported | PreToolUse + SessionStart hooks |
+| OpenCode direct session | Supported | Plugin enforces tool routing |
+| OpenCode spawned child sessions | Partial | Permission inheritance issue upstream (#16491) |
+
+## Remediation notes
+
+- Maintain structured payload contract in both hosts.
+- Keep status lifecycle in session-start hook for host-agnostic readiness.
+- Document OpenCode #16491 and retain defensive subagent recovery protocol.

--- a/scripts/skill/references/runtime-contract.md
+++ b/scripts/skill/references/runtime-contract.md
@@ -1,0 +1,95 @@
+# Qartez Runtime Contract
+
+Defines qartez runtime states, denial payload schemas, and environment variables.
+
+## States
+
+| State | Meaning |
+|---|---|
+| `READY` | Index is available and queries should run normally |
+| `INDEXING` | Index build is in progress |
+| `UNAVAILABLE` | Index or runtime unavailable |
+| `CAPABILITY_MISMATCH` | Tool visible but not executable in current host/session |
+| `STALE` | Index present but potentially stale |
+| `RISK_ACK_REQUIRED` | Edit blocked pending `qartez_impact` acknowledgment |
+
+## Status file schema (`.qartez/status.json`)
+
+```json
+{
+  "schema_version": "1",
+  "state": "READY",
+  "project_root": "/absolute/path",
+  "index_version": "2026-04-17T12:34:56Z",
+  "languages": ["ts", "rs"],
+  "file_count": 1382,
+  "is_stale": false,
+  "stale_threshold_secs": 300,
+  "last_error": null,
+  "started_at": "2026-04-17T12:30:00Z",
+  "ready_at": "2026-04-17T12:34:56Z",
+  "progress_hint": null
+}
+```
+
+## Guard denial payloads
+
+### Built-in code tool denied
+
+```json
+{
+  "qartez": {
+    "type": "DENIED_BUILTIN_CODE_TOOL",
+    "tool_attempted": "read",
+    "file_path": "src/server/mod.ts",
+    "replacement": ["qartez_read", "qartez_outline"],
+    "reason_code": "SOURCE_CODE_REQUIRES_QARTEZ",
+    "retryable": true,
+    "state": "READY"
+  }
+}
+```
+
+### Index not ready
+
+```json
+{
+  "qartez": {
+    "type": "DENIED_BUILTIN_CODE_TOOL",
+    "tool_attempted": "grep",
+    "replacement": [],
+    "reason_code": "INDEX_NOT_READY",
+    "retryable": false,
+    "state": "INDEXING"
+  }
+}
+```
+
+### Load-bearing edit requires risk ack
+
+```json
+{
+  "qartez": {
+    "type": "RISK_ACK_REQUIRED",
+    "tool_attempted": "edit",
+    "file_path": "src/server/mod.rs",
+    "replacement": ["qartez_impact"],
+    "reason_code": "LOAD_BEARING_FILE",
+    "pagerank": 0.12,
+    "blast_radius": 34,
+    "retryable": true,
+    "ack_ttl_secs": 600
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `QARTEZ_GUARD_DISABLE` | unset | Set `1` to disable guard logic |
+| `QARTEZ_INDEX_PATH` | `.qartez` | Override index directory |
+| `QARTEZ_STATUS_PATH` | `.qartez/status.json` | Override status file path |
+| `QARTEZ_ACK_TTL_SECS` | `600` | Guard acknowledgment TTL seconds |
+| `QARTEZ_GUARD_PAGERANK_MIN` | `0.05` | Load-bearing PageRank threshold |
+| `QARTEZ_GUARD_BLAST_MIN` | `10` | Load-bearing blast radius threshold |

--- a/scripts/skill/references/subagent-contract.md
+++ b/scripts/skill/references/subagent-contract.md
@@ -1,0 +1,64 @@
+# Qartez Subagent Contract
+
+Defines delegated-session expectations for qartez-aware execution.
+
+## Delegation detection
+
+Treat a session as delegated when any of the following apply:
+
+- Prompt/session contains `<!-- OMO_INTERNAL_INITIATOR -->`
+- Session was created via a task/delegate mechanism
+
+## Entry protocol
+
+1. Check `.qartez/status.json`.
+2. If `READY` or `STALE`, proceed qartez-first.
+3. If `INDEXING`, avoid symbol-heavy queries until ready.
+4. If `UNAVAILABLE`/`CAPABILITY_MISMATCH`, report immediately.
+
+## Execution protocol
+
+- Start with qartez tools; do not lead with built-in code tools.
+- On denial, parse JSON payload and retry with `replacement`.
+- On `RISK_ACK_REQUIRED`, call `qartez_impact`, then retry edit.
+- Do not mark task complete on denial alone.
+
+## Parent-agent responsibilities
+
+- Include qartez preamble in delegated prompts.
+- Parse denial payloads from subagent logs and inject recovery instructions.
+- Parse and enforce execution footer contract.
+
+## Suggested delegated-task preamble
+
+```text
+QARTEZ ROUTING: use qartez tools for all code work.
+glob/ls/find -> qartez_map
+grep/rg -> qartez_grep or qartez_find
+read on source -> qartez_read or qartez_outline
+If built-in tool is denied, parse payload.replacement and retry immediately.
+Check .qartez/status.json before execution.
+End with QARTEZ_EXECUTION_REPORT footer.
+```
+
+## Execution footer template
+
+```md
+<!-- QARTEZ_EXECUTION_REPORT
+State: <READY|INDEXING|CAPABILITY_MISMATCH|UNAVAILABLE|STALE>
+Tools_used: <comma-separated list>
+Builtin_denials: <count by type or none>
+Recovery_actions: <retried mappings or none>
+Change_mode_used: <yes|no>
+Risk_ack_issued: <yes, paths|no>
+Residual_uncertainty: <text or none>
+Missing_capability: <text or none>
+-->
+```
+
+## oh-my-openagent advisory integration notes
+
+- Add delegate-task recovery loop: detect denial JSON payload and append retry instruction.
+- Expand skill-reminder targeting to delegated sessions.
+- Lower reminder threshold for short-lived spawned sessions.
+- Track upstream OpenCode MCP permission inheritance issue: #16491.

--- a/scripts/skill/references/tools.md
+++ b/scripts/skill/references/tools.md
@@ -1,301 +1,54 @@
 # Qartez Tools Reference
 
-Complete reference for all Qartez MCP tools, grouped by category.
-
----
-
-## Navigate
-
-Tools for finding files, symbols, and understanding project structure.
-
-### qartez_map
-
-Project skeleton view ranked by importance.
-
-- **When to use**: Starting a new exploration, finding files, understanding project layout.
-- **Trigger phrases**: "show project structure", "what files are in this project", "where is X located"
-- **Parameters**:
-  - `path` (optional) - Subdirectory to scope the map to
-  - `depth` (optional) - Maximum directory depth to display
-- **Returns**: Tree of files and directories with PageRank scores. Higher-ranked files are more central to the codebase.
-
-### qartez_find
-
-Jump directly to a symbol definition.
-
-- **When to use**: You know the symbol name and want its definition location.
-- **Trigger phrases**: "find definition of X", "where is X defined", "jump to X"
-- **Parameters**:
-  - `symbol` - Name of the symbol to find (function, type, constant, etc.)
-  - `kind` (optional) - Filter by symbol kind (function, struct, type, const, etc.)
-- **Returns**: File path, line number, and symbol kind for matching definitions.
-
-### qartez_grep
-
-Search symbols across the codebase by pattern.
-
-- **When to use**: Searching for symbols when you only know part of the name, or searching for a pattern across many files.
-- **Trigger phrases**: "search for X", "find all symbols matching X", "grep for X"
-- **Parameters**:
-  - `pattern` - Search pattern (supports regex)
-  - `kind` (optional) - Filter by symbol kind
-  - `path` (optional) - Scope search to a subdirectory
-- **Returns**: List of matching symbols with file paths and line numbers.
-
-### qartez_read
-
-Read symbol source code with semantic context.
-
-- **When to use**: Reading a specific symbol's implementation along with its surrounding context (imports, related types).
-- **Trigger phrases**: "show me the code for X", "read X", "what does X do"
-- **Parameters**:
-  - `symbol` - Symbol name to read
-  - `file_path` (optional) - Disambiguate when multiple files define the same symbol
-  - `context_lines` (optional) - Number of surrounding lines to include
-- **Returns**: Source code of the symbol with relevant context lines.
-
-### qartez_outline
-
-File symbol table (names, kinds, line numbers).
-
-- **When to use**: Getting a quick overview of a file's contents without reading full source. Cheaper than qartez_read for initial exploration.
-- **Trigger phrases**: "what's in this file", "outline of X", "list functions in X"
-- **Parameters**:
-  - `file_path` - Path to the file
-- **Returns**: List of symbols with their kinds (function, struct, const, etc.) and line numbers.
-
-### qartez_stats
-
-Language, LOC, and symbol count breakdown.
-
-- **When to use**: Understanding project scale and composition. Works at project or per-file level.
-- **Trigger phrases**: "how big is this project", "what languages", "project stats", "lines of code"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory or specific file
-- **Returns**: Breakdown by language with lines of code, file count, and symbol count.
-
----
-
-## Analyze
-
-Tools for understanding dependencies, usage patterns, and relationships.
-
-### qartez_impact
-
-Blast radius analysis for a file or symbol.
-
-- **When to use**: Before modifying any heavily-imported file or exported symbol. Required by the modification guard for load-bearing files.
-- **Trigger phrases**: "blast radius of X", "what depends on X", "impact analysis", "is it safe to change X"
-- **Parameters**:
-  - `file_path` - Path to the file to analyze
-  - `symbol` (optional) - Specific symbol within the file
-- **Returns**: PageRank score, direct dependents count, transitive blast radius, and list of affected files.
-
-### qartez_deps
-
-File dependency graph (imports and exports).
-
-- **When to use**: Understanding what a file depends on and what depends on it. Useful for visualizing module boundaries.
-- **Trigger phrases**: "what does X import", "dependency graph", "what depends on X"
-- **Parameters**:
-  - `file_path` - Path to the file
-  - `direction` (optional) - "imports", "exports", or "both" (default: "both")
-- **Returns**: Lists of imported and exported symbols with their source/target files.
-
-### qartez_refs
-
-All references to a symbol across the codebase.
-
-- **When to use**: Finding every usage of a symbol. Essential before renaming, removing, or changing a symbol's signature.
-- **Trigger phrases**: "who uses X", "find all references to X", "usages of X"
-- **Parameters**:
-  - `symbol` - Symbol name to find references for
-  - `file_path` (optional) - Disambiguate the symbol's definition file
-- **Returns**: List of files and lines where the symbol is referenced.
-
-### qartez_calls
-
-Call hierarchy: callers and callees of a function.
-
-- **When to use**: Tracing execution flow during debugging. Understanding how a function fits into the call graph.
-- **Trigger phrases**: "what calls X", "what does X call", "call hierarchy", "trace calls"
-- **Parameters**:
-  - `symbol` - Function name
-  - `direction` (optional) - "callers", "callees", or "both" (default: "both")
-  - `depth` (optional) - How many levels deep to trace
-- **Returns**: Tree of callers and/or callees with file paths and line numbers.
-
-### qartez_cochange
-
-Files that historically change together in git history.
-
-- **When to use**: Before editing a file, to discover other files you likely need to update. Based on git commit co-occurrence patterns.
-- **Trigger phrases**: "what changes with X", "co-change partners", "related changes"
-- **Parameters**:
-  - `file_path` - Path to the file
-  - `min_confidence` (optional) - Minimum co-change confidence threshold
-- **Returns**: Ranked list of files that frequently change alongside the target, with confidence scores.
-
-### qartez_context
-
-Related files for a set of files you plan to modify.
-
-- **When to use**: Before starting a multi-file change. Surfaces files you might miss that are related via dependencies, co-change, or shared symbols.
-- **Trigger phrases**: "what else should I change", "related files", "context for this change"
-- **Parameters**:
-  - `file_paths` - List of files you plan to modify
-- **Returns**: Ranked list of related files with reasons why each is relevant (dependency, co-change, shared symbol, etc.).
-
-### qartez_unused
-
-Find dead/unused exported symbols.
-
-- **When to use**: Cleaning up dead code. Identifying exports that no other file in the project consumes.
-- **Trigger phrases**: "find dead code", "unused exports", "what can I delete"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory
-  - `kind` (optional) - Filter by symbol kind
-- **Returns**: List of exported symbols with zero internal references.
-
----
-
-## Risk
-
-Tools for identifying high-risk code and enforcing architectural rules.
-
-### qartez_hotspots
-
-High-risk code: complexity x coupling x churn.
-
-- **When to use**: Prioritizing refactoring effort. Files with high scores across all three dimensions are the most likely sources of bugs and the best candidates for improvement.
-- **Trigger phrases**: "hotspots", "risky code", "what should I refactor", "technical debt"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory
-  - `top_n` (optional) - Number of results to return
-- **Returns**: Ranked list of files with composite hotspot scores and individual metrics for complexity, coupling, and churn.
-
-### qartez_clones
-
-Detect duplicate code via AST structural hashing.
-
-- **When to use**: Finding refactoring opportunities where similar logic has been copy-pasted. Unlike text-based duplicate detection, this finds structurally identical code even when variable names differ.
-- **Trigger phrases**: "find duplicates", "copy-paste detection", "clone detection", "DRY violations"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory
-  - `min_tokens` (optional) - Minimum clone size in AST tokens
-- **Returns**: Groups of structurally identical code blocks with file paths and line ranges.
-
-### qartez_boundaries
-
-Check architecture boundary rules defined in `.qartez/boundaries.toml`.
-
-- **When to use**: Verifying that code changes respect declared module boundaries. Run this before merging to catch architectural violations.
-- **Trigger phrases**: "check boundaries", "architecture rules", "module violations", "boundary check"
-- **Parameters**:
-  - `path` (optional) - Scope to specific files or directories
-- **Returns**: List of boundary violations (if any) with the rule that was broken and the offending import.
-
----
-
-## Refactor
-
-Tools that modify code across the codebase.
-
-### qartez_rename
-
-Rename a symbol across the entire codebase.
-
-- **When to use**: Renaming a function, type, constant, or other symbol. Updates all references automatically.
-- **Trigger phrases**: "rename X to Y", "change name of X"
-- **Parameters**:
-  - `symbol` - Current symbol name
-  - `new_name` - New name for the symbol
-  - `file_path` (optional) - Disambiguate the symbol's definition file
-- **Returns**: List of files modified and the number of references updated.
-
-### qartez_move
-
-Move a symbol from one file to another.
-
-- **When to use**: Reorganizing code by moving a function, type, or constant to a different file. Updates all imports and references.
-- **Trigger phrases**: "move X to Y", "extract X into Y", "relocate function"
-- **Parameters**:
-  - `symbol` - Symbol name to move
-  - `from_file` - Source file path
-  - `to_file` - Destination file path
-- **Returns**: List of files modified with updated import paths.
-
-### qartez_rename_file
-
-Rename a file and update all imports that reference it.
-
-- **When to use**: Renaming or relocating a file while keeping all imports valid.
-- **Trigger phrases**: "rename file X to Y", "move file", "change file path"
-- **Parameters**:
-  - `old_path` - Current file path
-  - `new_path` - New file path
-- **Returns**: List of files with updated import paths.
-
----
-
-## Build
-
-Tools for project-level operations and documentation generation.
-
-### qartez_project
-
-Detected toolchain information: test, build, and lint commands.
-
-- **When to use**: Understanding how to build, test, and lint a project. Detects package managers, build systems, and testing frameworks.
-- **Trigger phrases**: "how do I build this", "what test framework", "project setup"
-- **Parameters**: None
-- **Returns**: Detected build tool, test runner, linter, and their respective commands.
-
-### qartez_wiki
-
-Generate an architecture document via community detection.
-
-- **When to use**: Creating or updating architecture documentation. Groups files into logical modules based on dependency patterns and generates prose descriptions.
-- **Trigger phrases**: "generate architecture doc", "write ARCHITECTURE.md", "document the architecture"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory
-  - `detail` (optional) - Level of detail ("brief" or "full")
-- **Returns**: Markdown architecture document with module descriptions, key files, and dependency relationships.
-
----
-
-## Git-aware
-
-Tools that incorporate git history for richer analysis.
-
-### qartez_diff_impact
-
-Analyze the current git diff for blast radius and risk.
-
-- **When to use**: Before merging or committing. Evaluates the current set of changes for their impact on the rest of the codebase.
-- **Trigger phrases**: "check my changes", "pre-merge check", "diff impact", "is this safe to merge"
-- **Parameters**:
-  - `base` (optional) - Base branch or commit to diff against (default: HEAD)
-- **Returns**: Per-file impact scores for changed files, affected dependents, and overall risk assessment.
-
-### qartez_trend
-
-Historical trend analysis for metrics over git history.
-
-- **When to use**: Understanding how code quality metrics have changed over time. Tracks complexity, coupling, and size trends.
-- **Trigger phrases**: "show trends", "how has complexity changed", "metric history"
-- **Parameters**:
-  - `file_path` (optional) - Specific file to track
-  - `metric` (optional) - Specific metric to track
-  - `commits` (optional) - Number of historical commits to analyze
-- **Returns**: Time series of metric values across recent commits.
-
-### qartez_hierarchy
-
-Module hierarchy and nesting structure.
-
-- **When to use**: Understanding the logical module structure of the project, especially in languages with explicit module systems (Rust, Python, Go).
-- **Trigger phrases**: "module hierarchy", "module tree", "package structure"
-- **Parameters**:
-  - `path` (optional) - Scope to a subdirectory
-- **Returns**: Tree of modules/packages with their contained symbols and submodules.
+Canonical built-in → qartez routing map and tool catalog for this skill.
+
+## Routing map
+
+| Built-in tool | Qartez replacement |
+|---|---|
+| `glob` / `ls` / find | `qartez_map` |
+| `grep` / `rg` | `qartez_grep` (pattern search), `qartez_find` (exact symbol) |
+| `read` / `cat` on source | `qartez_read`, `qartez_outline` |
+| risk check before edit | `qartez_impact` |
+
+## Core navigation & reading
+
+- `qartez_map` — structural overview, ranked by importance
+- `qartez_find` — exact symbol definition lookup
+- `qartez_grep` — indexed symbol/body search
+- `qartez_read` — semantic symbol/file reads
+- `qartez_outline` — file symbol inventory
+- `qartez_stats` — repository metrics
+
+## Analysis & risk
+
+- `qartez_impact` — blast radius and risk ack trigger
+- `qartez_deps` — importers/imports graph view
+- `qartez_refs` — usages/references
+- `qartez_calls` — caller/callee hierarchy
+- `qartez_cochange` — historical co-change partners
+- `qartez_context` — smart related-file context set
+- `qartez_unused` — candidate dead exports
+- `qartez_hotspots` — complexity × coupling × churn
+- `qartez_clones` — structural duplication
+- `qartez_boundaries` — architecture-boundary checks
+
+## Refactor operations
+
+- `qartez_rename`
+- `qartez_move`
+- `qartez_rename_file`
+
+## Project/meta
+
+- `qartez_project` — build/test/lint detection and execution
+- `qartez_wiki` — architecture document generation
+- `qartez_diff_impact` — pre-merge diff risk
+- `qartez_trend` — metric trends from git history
+- `qartez_hierarchy` — type/module hierarchy exploration
+
+## Confidence reminders
+
+- Prefer exact/strong tools for critical decisions.
+- Treat `qartez_unused`, `qartez_clones` as heuristic.
+- Treat `qartez_cochange`, `qartez_hotspots`, `qartez_trend` as historical correlation.

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -34,6 +34,23 @@ const INSTRUCTIONS_MD: &str = include_str!("../../scripts/instructions.md");
 const SKILL_MD: &str = include_str!("../../scripts/skill/SKILL.md");
 const SKILL_TOOLS_MD: &str = include_str!("../../scripts/skill/references/tools.md");
 const SKILL_GUARD_MD: &str = include_str!("../../scripts/skill/references/guard.md");
+const SKILL_RUNTIME_CONTRACT_MD: &str =
+    include_str!("../../scripts/skill/references/runtime-contract.md");
+const SKILL_SUBAGENT_CONTRACT_MD: &str =
+    include_str!("../../scripts/skill/references/subagent-contract.md");
+const SKILL_HOST_MATRIX_MD: &str = include_str!("../../scripts/skill/references/host-matrix.md");
+const SKILL_CONFIDENCE_MODEL_MD: &str =
+    include_str!("../../scripts/skill/references/confidence-model.md");
+const SKILL_DOCTRINE_EXPLORE_MD: &str =
+    include_str!("../../scripts/skill/references/doctrine-explore.md");
+const SKILL_DOCTRINE_DEBUG_MD: &str =
+    include_str!("../../scripts/skill/references/doctrine-debug.md");
+const SKILL_DOCTRINE_REVIEW_MD: &str =
+    include_str!("../../scripts/skill/references/doctrine-review.md");
+const SKILL_DOCTRINE_REFACTOR_MD: &str =
+    include_str!("../../scripts/skill/references/doctrine-refactor.md");
+const SKILL_DOCTRINE_PREMERGE_MD: &str =
+    include_str!("../../scripts/skill/references/doctrine-premerge.md");
 
 // -- CLI ---------------------------------------------------------------------
 
@@ -1264,10 +1281,28 @@ fn install_skill(claude_dir: &Path) -> anyhow::Result<()> {
     let skill_path = skill_dir.join("SKILL.md");
     let tools_path = refs_dir.join("tools.md");
     let guard_path = refs_dir.join("guard.md");
+    let runtime_contract_path = refs_dir.join("runtime-contract.md");
+    let subagent_contract_path = refs_dir.join("subagent-contract.md");
+    let host_matrix_path = refs_dir.join("host-matrix.md");
+    let confidence_model_path = refs_dir.join("confidence-model.md");
+    let doctrine_explore_path = refs_dir.join("doctrine-explore.md");
+    let doctrine_debug_path = refs_dir.join("doctrine-debug.md");
+    let doctrine_review_path = refs_dir.join("doctrine-review.md");
+    let doctrine_refactor_path = refs_dir.join("doctrine-refactor.md");
+    let doctrine_premerge_path = refs_dir.join("doctrine-premerge.md");
 
     fs::write(&skill_path, SKILL_MD)?;
     fs::write(&tools_path, SKILL_TOOLS_MD)?;
     fs::write(&guard_path, SKILL_GUARD_MD)?;
+    fs::write(&runtime_contract_path, SKILL_RUNTIME_CONTRACT_MD)?;
+    fs::write(&subagent_contract_path, SKILL_SUBAGENT_CONTRACT_MD)?;
+    fs::write(&host_matrix_path, SKILL_HOST_MATRIX_MD)?;
+    fs::write(&confidence_model_path, SKILL_CONFIDENCE_MODEL_MD)?;
+    fs::write(&doctrine_explore_path, SKILL_DOCTRINE_EXPLORE_MD)?;
+    fs::write(&doctrine_debug_path, SKILL_DOCTRINE_DEBUG_MD)?;
+    fs::write(&doctrine_review_path, SKILL_DOCTRINE_REVIEW_MD)?;
+    fs::write(&doctrine_refactor_path, SKILL_DOCTRINE_REFACTOR_MD)?;
+    fs::write(&doctrine_premerge_path, SKILL_DOCTRINE_PREMERGE_MD)?;
 
     info(&format!("Skill installed: {}", skill_dir.display()));
     Ok(())


### PR DESCRIPTION
## Summary
- Adds structured, machine-readable qartez denial payloads in guard flows so agents can reliably recover from built-in tool denials by following replacement routes.
- Aligns Claude shell guard and OpenCode plugin behavior (glob/grep/read denial routing, load-bearing edit acknowledgment, and index readiness signaling).
- Introduces status lifecycle output in session-start (`INDEXING` → `READY`/`UNAVAILABLE`) via `.qartez/status.json` to support deterministic runtime gating.
- Expands and reorganizes skill references with runtime/subagent contracts, host matrix, confidence model, and doctrine docs; wires new references into setup installation.

## Why
Current guard and skill flows were partially host-specific and human-message driven, which made delegated/subagent execution brittle. This PR establishes a shared runtime contract and recovery protocol so qartez-first behavior is consistent, parseable, and automation-friendly across hosts.

## Scope
### Guard and runtime behavior
- `scripts/qartez-guard.sh`
- `scripts/opencode-plugin.ts`
- `scripts/qartez-session-start.sh`

### Skill and docs
- `scripts/skill/SKILL.md`
- `scripts/skill/references/guard.md`
- `scripts/skill/references/tools.md`
- new references:
  - `runtime-contract.md`
  - `subagent-contract.md`
  - `host-matrix.md`
  - `confidence-model.md`
  - `doctrine-explore.md`
  - `doctrine-debug.md`
  - `doctrine-review.md`
  - `doctrine-refactor.md`
  - `doctrine-premerge.md`
- snippets:
  - `scripts/AGENTS.md.snippet`
  - `scripts/CLAUDE.md.snippet`
  - `scripts/instructions.md`

### Installer wiring
- `src/bin/setup.rs` now installs all new skill reference files.

## Validation
- Shell scripts linted with `shellcheck`.
- LSP diagnostics clean on changed key files.
- `cargo test` currently has pre-existing baseline failures in the repository unrelated to these script/docs changes.