### PR TITLE
feat: add qartez_arch_review prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,11 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             archive: tar.xz
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            archive: tar.xz
-            musl: true
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-24.04-arm
-            archive: tar.xz
-            musl: true
+          # musl targets disabled: libgit2-sys/libssh2-sys pull openssl-sys,
+          # which cannot find OpenSSL on the default musl builder. Users on
+          # Alpine/musl hit install.sh's source-build fallback automatically.
+          # TODO: enable by disabling git2 default features or using vendored
+          # openssl, then add back to the matrix.
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,14 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             archive: tar.xz
-          # musl targets disabled: libgit2-sys/libssh2-sys pull openssl-sys,
-          # which cannot find OpenSSL on the default musl builder. Users on
-          # Alpine/musl hit install.sh's source-build fallback automatically.
-          # TODO: enable by disabling git2 default features or using vendored
-          # openssl, then add back to the matrix.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.xz
+            musl: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            archive: tar.xz
+            musl: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
@@ -200,7 +203,7 @@ jobs:
         run: ls -lah dist/
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ needs.checksums.outputs.tag }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
+      - name: Ensure Rust target installed
+        shell: bash
+        run: rustup target add "${{ matrix.target }}"
+
       - name: Cache cargo registry / git / target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.3] - 2026-04-18
+
+### Added
+
+- **Linux musl prebuilt binaries** - `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` archives are back in the release matrix, so Alpine and other musl-based distros install in under 10 seconds instead of falling through to the cargo build path.
+
+### Changed
+
+- **`git2` compiled without default features** - only local repository operations are used (Repository, BlameOptions, RevWalk, Signature), so the `ssh` and `https` transport features are now disabled. This removes `libssh2-sys` and `openssl-sys` from the dependency tree and unblocks musl cross-compilation on GitHub Actions runners that do not ship OpenSSL.
+
+### Fixed
+
+- **Node.js 20 deprecation warning in release workflow** - upgraded `softprops/action-gh-release` from v2.6.2 to v3.0.0, which runs on the Node 24 Actions runtime. GitHub is forcing Node 24 as the default on 2026-06-02.
+
 ## [0.7.2] - 2026-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,8 +775,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
  "url",
 ]
 
@@ -1160,9 +1158,7 @@ checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -1173,20 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -1326,7 +1308,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -1487,12 +1469,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -1658,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "qartez-mcp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qartez-mcp"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for codebase intelligence — tree-sitter indexing, PageRank, blast radius"
@@ -41,7 +41,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 console = "0.15"
 dialoguer = "0.11"
 fs4 = "0.13"
-git2 = "0.20.4"
+git2 = { version = "0.20.4", default-features = false }
 glob = { version = "0.3", optional = true }
 globset = "0.4"
 ignore = "0.4.25"

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Tools are organized into **tiers** with progressive disclosure. Core tools are a
 
 ## Workflow prompts
 
-Five ready-to-use recipes that chain the tools above in the right order. Invoke them as slash commands in Claude Code or any MCP client that supports prompts.
+Six ready-to-use recipes that chain the tools above in the right order. Invoke them as slash commands in Claude Code or any MCP client that supports prompts.
 
 | Prompt | What it does |
 |---|---|
@@ -271,6 +271,7 @@ Five ready-to-use recipes that chain the tools above in the right order. Invoke 
 | `/qartez_debug <symbol>` | Definition + callers + callees + references in one shot. |
 | `/qartez_onboard [area]` | Five-file reading list for new contributors, ranked by importance. |
 | `/qartez_pre_merge <files>` | Pre-merge safety check with a ship/hold recommendation. |
+| `/qartez_arch_review [focus]` | Architecture risk audit: single points of failure, coupling hotspots, unguarded entry points. |
 
 ---
 
@@ -484,7 +485,7 @@ Nine projects share the "MCP server for codebase intelligence" niche, sorted by 
 | **Toolchain command runner (test / build / lint)** | **Yes** | Shell only | No | No | No | No | No | No | No |
 | **Smart multi-signal context builder** | **Yes** | No | Partial | No | No | No | No | No | No |
 | **Batch diff impact analysis** | **Yes** | No | No | No | No | No | No | No | No |
-| **MCP prompt templates** | **Yes (5)** | No | Yes (5) | No | No | No | No | No | No |
+| **MCP prompt templates** | **Yes (6)** | No | Yes (5) | No | No | No | No | No | No |
 | **One-command multi-IDE install** | **Yes (19 IDEs, Rust wizard)** | No (manual) | Yes (9 IDEs) | No (manual) | Yes (10 IDEs) | Yes (10 agents) | No | No | No |
 | **Security scanning (regex + PageRank scoring)** | **Yes** | No | No | No | No | No | No | No | No |
 | **Complexity trend over git history** | **Yes** | No | No | No | No | No | No | No | No |
@@ -593,7 +594,7 @@ src/
   server/
     mod.rs                 MCP server entrypoint - dispatches to per-tool handlers
     tools/                 30 per-tool handler modules (one file per MCP tool)
-    prompts.rs             5 workflow prompt templates
+    prompts.rs             6 workflow prompt templates
     tiers.rs               Progressive tool disclosure (core/analysis/refactor/meta)
     cache.rs               Tree-sitter parse cache
     helpers.rs             Shared handler utilities

--- a/src/server/prompt_tests.rs
+++ b/src/server/prompt_tests.rs
@@ -8,7 +8,7 @@
 //!   * the caller-supplied argument interpolated back into the recipe
 //!   * references to every Qartez tool the recipe promises to invoke
 //!
-//! The `prompt_router()` assertion at the bottom verifies that all five
+//! The `prompt_router()` assertion at the bottom verifies that all six
 //! prompts are actually registered so a missing `#[prompt(name = ...)]`
 //! attribute cannot silently drop a slash command.
 
@@ -19,7 +19,8 @@ use tempfile::TempDir;
 
 use super::QartezServer;
 use super::prompts::{
-    SoulArchitectureArgs, SoulDebugArgs, SoulOnboardArgs, SoulPreMergeArgs, SoulReviewArgs,
+    SoulArchReviewArgs, SoulArchitectureArgs, SoulDebugArgs, SoulOnboardArgs, SoulPreMergeArgs,
+    SoulReviewArgs,
 };
 use crate::storage::schema;
 
@@ -160,7 +161,28 @@ fn qartez_pre_merge_prompt_handles_empty_file_list() {
 }
 
 #[test]
-fn prompt_router_registers_all_five_canned_prompts() {
+fn qartez_arch_review_prompt_biases_map_on_focus_keyword() {
+    let (server, _dir) = make_server();
+
+    let untargeted =
+        server.qartez_arch_review_prompt(Parameters(SoulArchReviewArgs { focus: None }));
+    let text_untargeted = user_text(&untargeted);
+    assert!(text_untargeted.contains("qartez_map"));
+    assert!(text_untargeted.contains("qartez_hotspots"));
+    assert!(text_untargeted.contains("qartez_boundaries"));
+    assert!(text_untargeted.contains("qartez_security"));
+    assert!(!text_untargeted.contains("boost_terms"));
+
+    let targeted = server.qartez_arch_review_prompt(Parameters(SoulArchReviewArgs {
+        focus: Some("auth".into()),
+    }));
+    let text_targeted = user_text(&targeted);
+    assert!(text_targeted.contains("boost_terms=[\"auth\"]"));
+    assert!(text_targeted.contains("focused on `auth`"));
+}
+
+#[test]
+fn prompt_router_registers_all_six_canned_prompts() {
     let router = QartezServer::prompt_router();
     let names: Vec<String> = router.list_all().into_iter().map(|p| p.name).collect();
 
@@ -170,6 +192,7 @@ fn prompt_router_registers_all_five_canned_prompts() {
         "qartez_debug",
         "qartez_onboard",
         "qartez_pre_merge",
+        "qartez_arch_review",
     ] {
         assert!(
             names.iter().any(|n| n == expected),

--- a/src/server/prompts.rs
+++ b/src/server/prompts.rs
@@ -52,6 +52,13 @@ pub struct SoulPreMergeArgs {
     pub files: String,
 }
 
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct SoulArchReviewArgs {
+    /// Optional area to focus on (e.g., "auth", "data pipeline", "external integrations").
+    pub focus: Option<String>,
+}
+
 fn user_text(text: String) -> Vec<PromptMessage> {
     vec![PromptMessage::new_text(PromptMessageRole::User, text)]
 }
@@ -278,5 +285,110 @@ impl QartezServer {
         };
         GetPromptResult::new(user_text(text))
             .with_description("Qartez pre-merge safety-check workflow".to_string())
+    }
+
+    /// Architecture risk audit: structural risks that emerge from module relationships.
+    #[prompt(
+        name = "qartez_arch_review",
+        description = "Architecture risk audit: single points of failure, unguarded entry points, abstraction leaks, silent degradation, and coupling hotspots. Optional argument: `focus` (area keyword)."
+    )]
+    pub fn qartez_arch_review_prompt(
+        &self,
+        Parameters(args): Parameters<SoulArchReviewArgs>,
+    ) -> GetPromptResult {
+        let focus = args
+            .focus
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        let (map_step, focus_note) = match focus {
+            Some(f) => (
+                format!(
+                    "1. Call `qartez_map` with `boost_terms=[\"{f}\"]`, `top_n=20`, and `format=\"detailed\"` \
+                     to get the PageRank-ranked project skeleton biased toward `{f}`."
+                ),
+                format!(" focused on `{f}`"),
+            ),
+            None => (
+                "1. Call `qartez_map` with `top_n=20` and `format=\"detailed\"` \
+                 to get the PageRank-ranked project skeleton."
+                    .to_string(),
+                String::new(),
+            ),
+        };
+
+        let text = format!(
+            "Perform an architecture risk audit of this codebase{focus_note} using Qartez.\n\
+             \n\
+             Run these tools in order. Steps 1-3 can run in parallel, then 4-6 sequentially:\n\
+             \n\
+             {map_step}\n\
+             2. Call `qartez_stats` (no arguments) for language mix, LOC, and symbol count.\n\
+             3. Call `qartez_security` (no arguments) for known security surface findings.\n\
+             4. Call `qartez_hotspots` with `top_n=10` to find where complexity, coupling, and churn concentrate.\n\
+             5. Call `qartez_boundaries` with `suggest=true` to see the Leiden-derived module clusters \
+                and where the natural architectural seams are.\n\
+             6. For the top 3 hotspot files from step 4, call `qartez_deps` with `file_path=<file>` \
+                to see their dependency fan-in and fan-out.\n\
+             7. Identify any files that look like network-facing entry points (HTTP handlers, server \
+                startup, route registration, CLI commands that start servers). For each, call \
+                `qartez_calls` with `name=<entry_symbol>` and `direction=\"callees\"`, `depth=3` \
+                to trace the call chain inward from the external surface.\n\
+             \n\
+             With all that data, analyze the codebase for these architectural risks:\n\
+             \n\
+             **Single points of failure** - High-PageRank modules with many dependents but no \
+             redundancy, fallback, or retry visible in their call chain. Ask: if this module \
+             fails or is unreachable, what degrades?\n\
+             \n\
+             **Unguarded entry points** - Symbols reachable from network-facing handlers where \
+             the call chain between handler and business logic has no authentication, authorization, \
+             or input validation step visible.\n\
+             \n\
+             **Abstraction leaks** - Protocols, traits, or interfaces where some concrete \
+             implementations skip methods, return stubs, or silently no-op. Look for abstract \
+             definitions whose call chains reach a concrete impl that does less than callers expect.\n\
+             \n\
+             **Silent degradation** - Error handling that swallows failures and returns defaults \
+             instead of propagating. Especially dangerous on external boundaries (API calls, \
+             database queries, network I/O) where a silent fallback hides an outage.\n\
+             \n\
+             **Coupling hotspots** - Modules that appear in multiple Leiden communities, or that \
+             have high fan-in from unrelated clusters. These are architectural bottlenecks that \
+             make changes risky and hard to test in isolation.\n\
+             \n\
+             **Missing resilience** - External API calls (HTTP clients, database connections, \
+             third-party SDKs) with no retry, backoff, timeout, or circuit-breaking visible \
+             in the call chain.\n\
+             \n\
+             Return a structured report:\n\
+             \n\
+             ## Architecture Risk Review\n\
+             \n\
+             ### Scope\n\
+             State what was analyzed: entry points identified, module count, language mix.\n\
+             \n\
+             ### Findings\n\
+             \n\
+             | # | Risk | Severity | Evidence | Recommendation |\n\
+             |---|------|----------|----------|----------------|\n\
+             \n\
+             For each finding:\n\
+             - **Risk**: one-line description of the structural problem\n\
+             - **Severity**: high / medium / low\n\
+             - **Evidence**: which Qartez tool surfaced it, with the specific file and symbol\n\
+             - **Recommendation**: concrete next step (not \"consider\" or \"evaluate\" - say what to do)\n\
+             \n\
+             ### Health summary\n\
+             Two to three sentences: overall architectural health, the single highest-priority \
+             risk, and whether the codebase is in good shape for its current scale.\n\
+             \n\
+             Only report findings you have evidence for from the tool output. Do not speculate \
+             about risks the tools did not surface. If an area looks clean, say so briefly and \
+             move on."
+        );
+        GetPromptResult::new(user_text(text))
+            .with_description("Qartez architecture risk audit workflow".to_string())
     }
 }

--- a/src/server/prompts.rs
+++ b/src/server/prompts.rs
@@ -328,7 +328,9 @@ impl QartezServer {
              3. Call `qartez_security` (no arguments) for known security surface findings.\n\
              4. Call `qartez_hotspots` with `top_n=10` to find where complexity, coupling, and churn concentrate.\n\
              5. Call `qartez_boundaries` with `suggest=true` to see the Leiden-derived module clusters \
-                and where the natural architectural seams are.\n\
+                and where the natural architectural seams are. If this returns a \"no cluster \
+                assignment\" message, run `qartez_wiki` first to generate the clusters, then \
+                retry `qartez_boundaries`.\n\
              6. For the top 3 hotspot files from step 4, call `qartez_deps` with `file_path=<file>` \
                 to see their dependency fan-in and fan-out.\n\
              7. Identify any files that look like network-facing entry points (HTTP handlers, server \


### PR DESCRIPTION
## Summary

- Adds a 6th MCP workflow prompt: `qartez_arch_review` — an architecture risk audit that orchestrates existing tools to find structural risks
- Supports an optional `focus` argument to bias toward a specific area (e.g., "auth", "data pipeline")
- Follows the existing prompt pattern in `prompts.rs` (declarative tool sequence + LLM synthesis instructions)

## What it does

The prompt tells the LLM to run these tools in order:

1. `qartez_map` — project skeleton (parallel)
2. `qartez_stats` — scale context (parallel)
3. `qartez_security` — security surface (parallel)
4. `qartez_hotspots` — complexity × coupling × churn
5. `qartez_boundaries suggest=true` — Leiden-derived module clusters
6. `qartez_deps` — fan-in/fan-out on top 3 hotspots
7. `qartez_calls` — call chains from network-facing entry points

Then synthesizes findings across six architectural risk categories:

| Category | What it catches |
|----------|----------------|
| Single points of failure | High-PageRank modules with no redundancy |
| Unguarded entry points | Network handlers → business logic with no auth in call chain |
| Abstraction leaks | Interfaces where some impls silently no-op |
| Silent degradation | Error handling that swallows failures on external boundaries |
| Coupling hotspots | Modules appearing in multiple Leiden communities |
| Missing resilience | External API calls with no retry/backoff/timeout |

Output is a structured markdown table (# / Risk / Severity / Evidence / Recommendation) plus a health summary.

## Testing

- Compiled and verified prompt is registered in the binary (`strings` confirms `qartez_arch_review`)
- Tested the workflow manually against a Python MCP server project (chitta)
- Security + hotspots + cochange produced useful findings; deps/calls were empty due to Python's `edges=0` import resolution limitation (known — not a prompt issue, works well on languages where qartez resolves imports)

## Test plan

- [ ] Build: `cargo build --release --bin qartez`
- [ ] Verify prompt registration: `strings target/release/qartez | grep qartez_arch_review`
- [ ] Run against a Rust/Go/TypeScript project with edges to validate the full graph-dependent workflow (steps 5-7)
- [ ] Run with `focus` argument to verify boost_terms integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)