### PR TITLE
fix: normalize wrapped file_path arguments in safe_resolve (compat shim)

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -108,13 +108,72 @@ impl QartezServer {
         }
     }
 
+    /// Normalize common wrapper syntax around a tool path argument.
+    ///
+    /// Some MCP clients (or copied tool traces) may pass values like:
+    /// - `` `src/main.rs` ``
+    /// - `"src/main.rs"`
+    /// - `'src/main.rs'`
+    /// - `[file_path=src/main.rs]`
+    /// - `file_path=src/main.rs`
+    ///
+    /// This helper strips one or more wrapper layers before path validation.
+    fn normalize_user_path_arg(raw: &str) -> String {
+        let mut s = raw.trim().to_string();
+
+        loop {
+            let before = s.clone();
+
+            // Strip one bracket layer for copied tool-log assignments:
+            // [file_path=...], [path=...], [file=...]
+            if s.starts_with('[') && s.ends_with(']') && s.len() >= 2 {
+                let inner = s[1..s.len() - 1].trim();
+                if inner.starts_with("file_path=")
+                    || inner.starts_with("path=")
+                    || inner.starts_with("file=")
+                {
+                    s = inner.to_string();
+                }
+            }
+
+            // Strip common key prefixes copied from tool logs.
+            if let Some(rest) = s.strip_prefix("file_path=") {
+                s = rest.trim().to_string();
+            } else if let Some(rest) = s.strip_prefix("path=") {
+                s = rest.trim().to_string();
+            } else if let Some(rest) = s.strip_prefix("file=") {
+                s = rest.trim().to_string();
+            }
+
+            // Strip one matching quote/backtick layer.
+            if s.len() >= 2 {
+                let first = s.as_bytes()[0] as char;
+                let last = s.as_bytes()[s.len() - 1] as char;
+                if first == last && matches!(first, '\'' | '"' | '`') {
+                    s = s[1..s.len() - 1].trim().to_string();
+                }
+            }
+
+            if s == before {
+                break;
+            }
+        }
+
+        s
+    }
+
     /// Resolve a user-supplied relative path against the project root(s),
     /// rejecting absolute paths and directory traversal beyond the root.
     fn safe_resolve(&self, user_path: &str) -> Result<PathBuf, String> {
-        let path = std::path::Path::new(user_path);
+        let normalized = Self::normalize_user_path_arg(user_path);
+        if normalized.is_empty() {
+            return Err("Path must not be empty".to_string());
+        }
+
+        let path = std::path::Path::new(&normalized);
         if path.is_absolute() {
             return Err(format!(
-                "Path '{user_path}' must be relative to the project root"
+                "Path '{normalized}' must be relative to the project root"
             ));
         }
         let mut depth: isize = 0;
@@ -123,7 +182,7 @@ impl QartezServer {
                 std::path::Component::ParentDir => {
                     depth -= 1;
                     if depth < 0 {
-                        return Err(format!("Path '{user_path}' escapes the project root"));
+                        return Err(format!("Path '{normalized}' escapes the project root"));
                     }
                 }
                 std::path::Component::Normal(_) => {
@@ -132,7 +191,7 @@ impl QartezServer {
                 std::path::Component::CurDir => {}
                 _ => {
                     return Err(format!(
-                        "Path '{user_path}' must be relative to the project root"
+                        "Path '{normalized}' must be relative to the project root"
                     ));
                 }
             }
@@ -145,7 +204,7 @@ impl QartezServer {
             return Ok(resolved);
         }
 
-        Ok(self.project_root.join(user_path))
+        Ok(self.project_root.join(&normalized))
     }
 
     /// Acquire the server's shared SQLite connection under its mutex.
@@ -637,6 +696,47 @@ mod safe_resolve_tests {
         let result = server.safe_resolve("../sibling/file.rs");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("escapes"));
+    }
+
+    #[test]
+    fn accepts_backtick_wrapped_path() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("`src/main.rs`");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            std::path::PathBuf::from("/tmp/project/src/main.rs")
+        );
+    }
+
+    #[test]
+    fn accepts_bracketed_file_path_assignment() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("[file_path=src/main.rs]");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            std::path::PathBuf::from("/tmp/project/src/main.rs")
+        );
+    }
+
+    #[test]
+    fn wrapped_traversal_is_still_rejected() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("`../secret.txt`");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("escapes"));
+    }
+
+    #[test]
+    fn preserves_literal_bracket_filename() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("[notes].md");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            std::path::PathBuf::from("/tmp/project/[notes].md")
+        );
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -108,41 +108,34 @@ impl QartezServer {
         }
     }
 
-    /// Normalize common wrapper syntax around a tool path argument.
+    /// Compatibility shim for clients that pass wrapper syntax around path args.
     ///
     /// Some MCP clients (or copied tool traces) may pass values like:
     /// - `` `src/main.rs` ``
     /// - `"src/main.rs"`
     /// - `'src/main.rs'`
     /// - `[file_path=src/main.rs]`
-    /// - `file_path=src/main.rs`
     ///
-    /// This helper strips one or more wrapper layers before path validation.
+    /// This helper strips quote/backtick wrappers and bracketed assignment
+    /// wrappers before path validation. Bare literals such as `file=notes.md`
+    /// are preserved because the `=` may be part of the filename itself.
     fn normalize_user_path_arg(raw: &str) -> String {
         let mut s = raw.trim().to_string();
 
         loop {
             let before = s.clone();
 
-            // Strip one bracket layer for copied tool-log assignments:
+            // Strip one bracket wrapper for copied tool-log assignments:
             // [file_path=...], [path=...], [file=...]
             if s.starts_with('[') && s.ends_with(']') && s.len() >= 2 {
                 let inner = s[1..s.len() - 1].trim();
-                if inner.starts_with("file_path=")
-                    || inner.starts_with("path=")
-                    || inner.starts_with("file=")
-                {
-                    s = inner.to_string();
+                if let Some(rest) = inner.strip_prefix("file_path=") {
+                    s = rest.trim().to_string();
+                } else if let Some(rest) = inner.strip_prefix("path=") {
+                    s = rest.trim().to_string();
+                } else if let Some(rest) = inner.strip_prefix("file=") {
+                    s = rest.trim().to_string();
                 }
-            }
-
-            // Strip common key prefixes copied from tool logs.
-            if let Some(rest) = s.strip_prefix("file_path=") {
-                s = rest.trim().to_string();
-            } else if let Some(rest) = s.strip_prefix("path=") {
-                s = rest.trim().to_string();
-            } else if let Some(rest) = s.strip_prefix("file=") {
-                s = rest.trim().to_string();
             }
 
             // Strip one matching quote/backtick layer.
@@ -729,6 +722,14 @@ mod safe_resolve_tests {
     }
 
     #[test]
+    fn rejects_empty_after_normalization() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("[file_path=   ]");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Path must not be empty");
+    }
+
+    #[test]
     fn preserves_literal_bracket_filename() {
         let server = dummy_server(std::path::Path::new("/tmp/project"));
         let result = server.safe_resolve("[notes].md");
@@ -736,6 +737,17 @@ mod safe_resolve_tests {
         assert_eq!(
             result.unwrap(),
             std::path::PathBuf::from("/tmp/project/[notes].md")
+        );
+    }
+
+    #[test]
+    fn preserves_literal_assignment_like_filename() {
+        let server = dummy_server(std::path::Path::new("/tmp/project"));
+        let result = server.safe_resolve("file=notes.md");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            std::path::PathBuf::from("/tmp/project/file=notes.md")
         );
     }
 }


### PR DESCRIPTION
## Purpose
Land a narrowly scoped compatibility fix in `safe_resolve` for wrapped path arguments copied from tool traces (quotes/backticks and bracketed assignment wrappers).

## Summary
- Rebased/cherry-picked the branch onto current upstream `main` and dropped unrelated release-scope changes from this PR.
- Kept `safe_resolve` in the current `main` structure (`project_roots: Arc<RwLock<...>>` + `helpers::resolve_prefixed_path`) and applied normalization at the top of the function.
- Framed normalization explicitly as a **compat shim** for clients embedding assignment syntax in arguments.
- Limited assignment-prefix stripping to **bracketed wrappers only** (`[file_path=...]`, `[path=...]`, `[file=...]`).
- Preserved bare literal filenames such as `file=notes.md` (no bare-prefix stripping).
- Added/updated `safe_resolve` regressions for:
  - wrapped path acceptance,
  - wrapped traversal rejection,
  - empty-after-normalization rejection,
  - literal bracket filename preservation,
  - literal `file=...` filename preservation.

## Why
Some clients pass copied wrapper syntax (`[file_path=...]`, quoted/backticked paths) as argument values. Treating wrappers as literal path characters causes avoidable lookup failures. This PR compensates at the server boundary for ergonomics while keeping absolute/traversal protections intact and avoiding risky broad parsing semantics.

## Validation
- `cargo test -q safe_resolve -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-targets`
- `cargo test --all-targets`

## Scope notes
Per project convention and review feedback, this PR intentionally excludes changelog/version/release-workflow/dependency-release edits.