### PR TITLE
feat: workspace.toml support and qartez_workspace tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,25 @@ When a root contains a workspace config, qartez expands it automatically:
 Each workspace member becomes an additional root. The original root is kept
 (it often contains shared config, scripts, etc.).
 
+### Explicit workspaces (`.qartez/workspace.toml`)
+
+For cases where you want to include unrelated directories or use custom prefixes
+(domains) for your projects, create a `.qartez/workspace.toml` file in your
+project root:
+
+```toml
+[workspaces]
+# Key = Alias/Prefix used in path results
+# Value = Path to the project (absolute, relative, or ~/ expansion)
+Core = "../qartez-core"
+Legacy = "~/old-projects/v1"
+```
+
+Files within these roots will be prefixed with the alias (e.g.,
+`Core/src/lib.rs`) instead of their directory name. This is the recommended
+way to handle multi-app porting or monorepo-style development across
+disparate folders.
+
 ## Database location
 
 - **Single-root** — `.qartez/index.db` inside the project root

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,13 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use serde::Serialize;
 use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceAction {
+    Add,
+    Remove,
+}
 
 /// Output format for CLI commands.
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
@@ -219,5 +227,14 @@ pub enum Command {
         /// Optional task description to help prioritize
         #[arg(long)]
         task: Option<String>,
+    },
+
+    /// Manage project domains (workspaces) dynamically
+    Workspace {
+        action: WorkspaceAction,
+        /// The alias (domain name) for the project
+        alias: String,
+        /// The path to the project directory (required for 'add')
+        path: Option<String>,
     },
 }

--- a/src/cli_runner.rs
+++ b/src/cli_runner.rs
@@ -23,7 +23,12 @@ pub fn run(config: &Config, command: &Command, format: OutputFormat) -> Result<(
 
     if config.has_project {
         eprintln!("Indexing...");
-        index::full_index_multi(&conn, &config.project_roots, config.reindex)?;
+        index::full_index_multi(
+            &conn,
+            &config.project_roots,
+            &config.root_aliases,
+            config.reindex,
+        )?;
         graph::pagerank::compute_pagerank(&conn, &Default::default())?;
         graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())?;
         git::cochange::analyze_cochanges(
@@ -37,7 +42,13 @@ pub fn run(config: &Config, command: &Command, format: OutputFormat) -> Result<(
         eprintln!("Index ready.");
     }
 
-    let server = QartezServer::new(conn, config.primary_root.clone(), config.git_depth);
+    let server = QartezServer::with_roots(
+        conn,
+        config.primary_root.clone(),
+        config.project_roots.clone(),
+        config.root_aliases.clone(),
+        config.git_depth,
+    );
 
     let (tool_name, args) = build_tool_call(command);
 
@@ -204,6 +215,19 @@ fn build_tool_call(command: &Command) -> (String, serde_json::Value) {
                 args["task"] = json!(t);
             }
             ("qartez_context".into(), args)
+        }
+
+        Command::Workspace {
+            action,
+            alias,
+            path,
+        } => {
+            let args = json!({
+                "action": action,
+                "alias": alias,
+                "path": path,
+            });
+            ("qartez_workspace".into(), args)
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::cli::Cli;
@@ -5,6 +6,7 @@ use crate::error::Result;
 
 pub struct Config {
     pub project_roots: Vec<PathBuf>,
+    pub root_aliases: HashMap<PathBuf, String>,
     pub primary_root: PathBuf,
     pub db_path: PathBuf,
     pub reindex: bool,
@@ -57,19 +59,58 @@ fn detect_child_project_roots(dir: &Path) -> Vec<PathBuf> {
     roots
 }
 
+fn detect_qartez_workspace(root: &Path) -> (Vec<PathBuf>, HashMap<PathBuf, String>) {
+    let config_path = root.join(".qartez").join("workspace.toml");
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return (Vec::new(), HashMap::new()),
+    };
+
+    let doc: toml_edit::DocumentMut = match content.parse() {
+        Ok(v) => v,
+        Err(_) => return (Vec::new(), HashMap::new()),
+    };
+
+    let mut roots = Vec::new();
+    let mut aliases = HashMap::new();
+
+    if let Some(workspaces) = doc.get("workspaces").and_then(|w| w.as_table()) {
+        for (alias, value) in workspaces.iter() {
+            let path_str = match value.as_str() {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let path = expand_path(path_str, root);
+
+            if let Ok(canonical) = path.canonicalize() {
+                roots.push(canonical.clone());
+                aliases.insert(canonical, alias.to_string());
+            } else if path.is_dir() {
+                roots.push(path.clone());
+                aliases.insert(path, alias.to_string());
+            }
+        }
+    }
+
+    (roots, aliases)
+}
+
 /// Detect workspace member directories from workspace config files.
 ///
 /// Checks for npm/yarn/pnpm (`package.json` `"workspaces"`), Cargo
 /// (`Cargo.toml` `[workspace] members`), and Go (`go.work` `use`
 /// directives). Returned paths are absolute and sorted.
-fn detect_workspace_members(root: &Path) -> Vec<PathBuf> {
+fn detect_workspace_members(root: &Path) -> (Vec<PathBuf>, HashMap<PathBuf, String>) {
     let mut members = Vec::new();
+    let (qartez_roots, qartez_aliases) = detect_qartez_workspace(root);
+    members.extend(qartez_roots);
     members.extend(detect_npm_workspace(root));
     members.extend(detect_cargo_workspace(root));
     members.extend(detect_go_workspace(root));
     members.sort();
     members.dedup();
-    members
+    (members, qartez_aliases)
 }
 
 /// Parse `package.json` `"workspaces"` field and expand globs.
@@ -229,28 +270,40 @@ fn expand_workspace_globs(root: &Path, patterns: &[&str]) -> Vec<PathBuf> {
 /// into additional roots. The original root is kept (it may contain shared
 /// config, scripts, etc.), and members are appended after it. Duplicates
 /// are removed.
-fn expand_roots_with_workspaces(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+fn expand_roots_with_workspaces(roots: Vec<PathBuf>) -> (Vec<PathBuf>, HashMap<PathBuf, String>) {
     let mut expanded = Vec::new();
     let mut seen = std::collections::HashSet::new();
+    let mut all_aliases = HashMap::new();
     for root in &roots {
         let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
         if seen.insert(canonical.clone()) {
             expanded.push(root.clone());
         }
-        for member in detect_workspace_members(root) {
+        let (members, aliases) = detect_workspace_members(root);
+        all_aliases.extend(aliases);
+        for member in members {
             let member_canonical = member.canonicalize().unwrap_or_else(|_| member.clone());
             if seen.insert(member_canonical) {
                 expanded.push(member);
             }
         }
     }
-    expanded
+    (expanded, all_aliases)
+}
+
+/// Expand a path string relative to `base`, handling `~/` home expansion.
+pub(crate) fn expand_path(path_str: &str, base: &Path) -> PathBuf {
+    if let Some(rest) = path_str.strip_prefix("~/") {
+        if let Some(home) = cross_platform_home() {
+            return home.join(rest);
+        }
+    }
+    base.join(path_str)
 }
 
 /// Cross-platform home directory detection.
 /// Checks HOME (Unix), USERPROFILE (Windows), HOMEDRIVE+HOMEPATH (Windows).
-fn cross_platform_home() -> Option<PathBuf> {
-    // Try HOME (Unix)
+pub fn cross_platform_home() -> Option<PathBuf> {
     if let Some(home) = std::env::var_os("HOME") {
         return Some(PathBuf::from(home));
     }
@@ -301,7 +354,7 @@ impl Config {
 
         // Expand workspace members: if any root has a workspace config
         // (npm, Cargo, Go), add member directories as additional roots.
-        let project_roots = expand_roots_with_workspaces(project_roots);
+        let (project_roots, root_aliases) = expand_roots_with_workspaces(project_roots);
 
         let primary_root = project_roots[0].clone();
 
@@ -322,11 +375,57 @@ impl Config {
 
         Ok(Config {
             project_roots,
+            root_aliases,
             primary_root,
             db_path,
             reindex: cli.reindex,
             git_depth: cli.git_depth,
             has_project,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_detect_qartez_workspace_expansion() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let other = TempDir::new().unwrap();
+        let other_path = other.path();
+
+        let qartez_dir = root.join(".qartez");
+        std::fs::create_dir_all(&qartez_dir).unwrap();
+
+        let config_toml = format!(
+            r#"
+[workspaces]
+Other = "{}"
+Relative = "subproject"
+"#,
+            other_path.to_string_lossy().replace('\\', "/")
+        );
+        std::fs::write(qartez_dir.join("workspace.toml"), config_toml).unwrap();
+
+        let subproject = root.join("subproject");
+        std::fs::create_dir_all(&subproject).unwrap();
+
+        let (roots, aliases) = detect_qartez_workspace(root);
+
+        assert_eq!(roots.len(), 2);
+
+        let other_canonical = other_path
+            .canonicalize()
+            .unwrap_or(other_path.to_path_buf());
+        let sub_canonical = subproject.canonicalize().unwrap_or(subproject);
+
+        assert!(roots.contains(&other_canonical));
+        assert!(roots.contains(&sub_canonical));
+
+        assert_eq!(aliases.get(&other_canonical).unwrap(), "Other");
+        assert_eq!(aliases.get(&sub_canonical).unwrap(), "Relative");
     }
 }

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -87,6 +87,7 @@ mod tests {
     #[test]
     fn changed_files_between_commits() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit(&repo, dir.path(), &[("a.txt", "hello")], "first");
         make_commit(
@@ -105,6 +106,7 @@ mod tests {
     #[test]
     fn single_ref_implies_to_head() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit(&repo, dir.path(), &[("a.txt", "v1")], "first");
         make_commit(&repo, dir.path(), &[("b.txt", "v1")], "second");
@@ -117,6 +119,7 @@ mod tests {
     #[test]
     fn no_changes_returns_empty() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit(&repo, dir.path(), &[("a.txt", "v1")], "first");
 
@@ -127,6 +130,7 @@ mod tests {
     #[test]
     fn invalid_revspec_returns_error() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let _repo = init_repo(dir.path());
         let result = changed_files_in_range(dir.path(), "nonexistent..HEAD");
         assert!(result.is_err());
@@ -135,6 +139,7 @@ mod tests {
     #[test]
     fn not_a_git_repo_returns_error() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let result = changed_files_in_range(dir.path(), "main..HEAD");
         assert!(result.is_err());
     }

--- a/src/git/knowledge.rs
+++ b/src/git/knowledge.rs
@@ -302,6 +302,7 @@ mod tests {
     #[test]
     fn analyze_single_author_repo() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit(
             &repo,
@@ -320,6 +321,7 @@ mod tests {
     #[test]
     fn analyze_two_authors() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit_as(
             &repo,
@@ -350,6 +352,7 @@ mod tests {
     #[test]
     fn author_filter_excludes_unmatched() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit_as(
             &repo,
@@ -405,6 +408,7 @@ mod tests {
     #[test]
     fn analyze_empty_file_list() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let _repo = init_repo(dir.path());
         let result = analyze_knowledge(dir.path(), &[], None).unwrap();
         assert!(result.is_empty());
@@ -413,6 +417,7 @@ mod tests {
     #[test]
     fn analyze_nonexistent_file_skipped() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit(&repo, dir.path(), &[("exists.rs", "fn f() {}\n")], "init");
         let result = analyze_knowledge(
@@ -428,6 +433,7 @@ mod tests {
     #[test]
     fn analyze_non_git_directory_returns_error() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let result = analyze_knowledge(dir.path(), &["any.rs".into()], None);
         assert!(result.is_err(), "should fail on non-git directory");
     }
@@ -435,6 +441,7 @@ mod tests {
     #[test]
     fn author_filter_case_insensitive() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit_as(
             &repo,
@@ -519,6 +526,7 @@ mod tests {
     #[test]
     fn analyze_total_lines_matches_file_content() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         let content = "line1\nline2\nline3\nline4\nline5\n";
         make_commit(&repo, dir.path(), &[("five_lines.rs", content)], "init");
@@ -533,6 +541,7 @@ mod tests {
     #[test]
     fn analyze_multiple_files_independent() {
         let dir = tempfile::tempdir().expect("failed to create tempdir");
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
         let repo = init_repo(dir.path());
         make_commit_as(
             &repo,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -63,7 +63,12 @@ pub fn full_index(conn: &Connection, root: &Path, force: bool) -> Result<()> {
 /// collision on the UNIQUE `files.path` column.
 ///
 /// For single-root mode, delegates to `full_index` with no prefix.
-pub fn full_index_multi(conn: &Connection, roots: &[PathBuf], force: bool) -> Result<()> {
+pub fn full_index_multi(
+    conn: &Connection,
+    roots: &[PathBuf],
+    aliases: &HashMap<PathBuf, String>,
+    force: bool,
+) -> Result<()> {
     if roots.len() <= 1 {
         if let Some(root) = roots.first() {
             return full_index(conn, root, force);
@@ -78,11 +83,15 @@ pub fn full_index_multi(conn: &Connection, roots: &[PathBuf], force: bool) -> Re
     // We insert BOTH the prefixed form (for DB lookups and stale-file
     // detection) and the unprefixed raw form (for import resolvers, which
     // generate candidates relative to a single root).
+    let roots_with_prefixes: Vec<(&PathBuf, String)> = roots
+        .iter()
+        .map(|r| (r, root_prefix(r, aliases.get(r).map(|s| s.as_str()))))
+        .collect();
+
     let mut all_known: HashSet<String> = HashSet::new();
-    for root in roots {
-        let prefix = root_prefix(root);
+    for (root, prefix) in &roots_with_prefixes {
         for file_path in walker::walk_source_files(root) {
-            let raw_rel = match file_path.strip_prefix(root) {
+            let raw_rel = match file_path.strip_prefix(*root) {
                 Ok(p) => to_forward_slash(p.to_string_lossy().into_owned()),
                 Err(_) => to_forward_slash(file_path.to_string_lossy().into_owned()),
             };
@@ -90,17 +99,19 @@ pub fn full_index_multi(conn: &Connection, roots: &[PathBuf], force: bool) -> Re
             all_known.insert(raw_rel);
         }
     }
-    for root in roots {
-        let prefix = root_prefix(root);
+    for (root, prefix) in &roots_with_prefixes {
         tracing::info!("Indexing root: {} (prefix: {prefix})", root.display());
-        full_index_root(conn, root, force, &prefix, &all_known)?;
+        full_index_root(conn, root, force, prefix, &all_known)?;
     }
     Ok(())
 }
 
 /// Extract the directory name of a root, used as the path prefix in
 /// multi-root mode (e.g. `/home/user/repo-a` -> `"repo-a"`).
-fn root_prefix(root: &Path) -> String {
+fn root_prefix(root: &Path, alias: Option<&str>) -> String {
+    if let Some(a) = alias {
+        return a.to_string();
+    }
     root.file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "root".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,12 @@ async fn main() -> anyhow::Result<()> {
             // Wiki generation depends on a fresh index + pagerank + co-change,
             // and the CLI caller is explicitly waiting for the output file.
             // Keep this path synchronous.
-            index::full_index_multi(&conn, &config.project_roots, config.reindex)?;
+            index::full_index_multi(
+                &conn,
+                &config.project_roots,
+                &config.root_aliases,
+                config.reindex,
+            )?;
             graph::pagerank::compute_pagerank(&conn, &Default::default())?;
             graph::pagerank::compute_symbol_pagerank(&conn, &Default::default())?;
             git::cochange::analyze_cochanges(
@@ -104,6 +109,7 @@ async fn main() -> anyhow::Result<()> {
             // run (empty on first-ever start).
             let db_path = config.db_path.clone();
             let project_roots = config.project_roots.clone();
+            let root_aliases = config.root_aliases.clone();
             let primary_root = config.primary_root.clone();
             let reindex = config.reindex;
             let git_depth = config.git_depth;
@@ -115,7 +121,9 @@ async fn main() -> anyhow::Result<()> {
                         return;
                     }
                 };
-                if let Err(e) = index::full_index_multi(&conn, &project_roots, reindex) {
+                if let Err(e) =
+                    index::full_index_multi(&conn, &project_roots, &root_aliases, reindex)
+                {
                     tracing::error!("background indexer: full_index_multi failed: {e}");
                     return;
                 }
@@ -150,6 +158,7 @@ async fn main() -> anyhow::Result<()> {
         conn,
         config.primary_root,
         config.project_roots.clone(),
+        config.root_aliases.clone(),
         config.git_depth,
     );
 

--- a/src/server/helpers.rs
+++ b/src/server/helpers.rs
@@ -6,13 +6,51 @@ use std::collections::HashMap;
 
 use crate::str_utils::floor_char_boundary;
 
+/// Resolve a prefixed multi-root path (e.g. `"MyAlias/src/lib.rs"`) to an
+/// absolute path by matching its first component against known roots and
+/// aliases. Returns `None` when there is only one root or no prefix matches.
+pub(super) fn resolve_prefixed_path(
+    path: &std::path::Path,
+    roots: &[std::path::PathBuf],
+    aliases: &HashMap<std::path::PathBuf, String>,
+) -> Option<std::path::PathBuf> {
+    if roots.len() <= 1 {
+        return None;
+    }
+    let first = match path.components().next() {
+        Some(std::path::Component::Normal(n)) => n,
+        _ => return None,
+    };
+    let first_str = first.to_string_lossy();
+    for root in roots {
+        let alias = aliases.get(root).map(|s| s.as_str());
+        let matches = if let Some(a) = alias {
+            first_str == a
+        } else {
+            root.file_name()
+                .map(|n| n.to_string_lossy() == first_str)
+                .unwrap_or(false)
+        };
+        if matches {
+            let remainder: std::path::PathBuf = path.components().skip(1).collect();
+            return Some(root.join(remainder));
+        }
+    }
+    None
+}
+
 pub(super) fn elide_file_source(
     project_root: &std::path::Path,
+    project_roots: &[std::path::PathBuf],
+    root_aliases: &HashMap<std::path::PathBuf, String>,
     file_path: &str,
     symbols: &[crate::storage::models::SymbolRow],
     token_budget_remaining: usize,
 ) -> Option<String> {
-    let abs_path = project_root.join(file_path);
+    let path = std::path::Path::new(file_path);
+    let abs_path = resolve_prefixed_path(path, project_roots, root_aliases)
+        .unwrap_or_else(|| project_root.join(file_path));
+
     let source = std::fs::read_to_string(&abs_path).ok()?;
     let lines: Vec<&str> = source.lines().collect();
     if lines.is_empty() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -41,7 +41,8 @@ use crate::toolchain;
 pub struct QartezServer {
     db: Arc<Mutex<Connection>>,
     project_root: PathBuf,
-    project_roots: Vec<PathBuf>,
+    project_roots: Arc<RwLock<Vec<PathBuf>>>,
+    root_aliases: Arc<RwLock<HashMap<PathBuf, String>>>,
     git_depth: u32,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
@@ -52,13 +53,14 @@ pub struct QartezServer {
 impl QartezServer {
     pub fn new(conn: Connection, project_root: PathBuf, git_depth: u32) -> Self {
         let project_roots = vec![project_root.clone()];
-        Self::with_roots(conn, project_root, project_roots, git_depth)
+        Self::with_roots(conn, project_root, project_roots, HashMap::new(), git_depth)
     }
 
     pub fn with_roots(
         conn: Connection,
         project_root: PathBuf,
         project_roots: Vec<PathBuf>,
+        root_aliases: HashMap<PathBuf, String>,
         git_depth: u32,
     ) -> Self {
         // Self-heal the body FTS index. Existing `.qartez/index.db` files
@@ -97,7 +99,8 @@ impl QartezServer {
         Self {
             db: Arc::new(Mutex::new(conn)),
             project_root,
-            project_roots,
+            project_roots: Arc::new(RwLock::new(project_roots)),
+            root_aliases: Arc::new(RwLock::new(root_aliases)),
             git_depth,
             tool_router: router,
             parse_cache: Arc::new(Mutex::new(ParseCache::default())),
@@ -135,20 +138,11 @@ impl QartezServer {
             }
         }
 
-        if self.project_roots.len() > 1
-            && let Some(std::path::Component::Normal(first)) = path.components().next()
-        {
-            let first_str = first.to_string_lossy();
-            for root in &self.project_roots {
-                let root_name = root
-                    .file_name()
-                    .map(|n| n.to_string_lossy())
-                    .unwrap_or_default();
-                if first_str == root_name {
-                    let remainder: PathBuf = path.components().skip(1).collect();
-                    return Ok(root.join(remainder));
-                }
-            }
+        let roots = self.project_roots.read().map_err(|e| e.to_string())?;
+        let aliases = self.root_aliases.read().map_err(|e| e.to_string())?;
+
+        if let Some(resolved) = helpers::resolve_prefixed_path(path, &roots, &aliases) {
+            return Ok(resolved);
         }
 
         Ok(self.project_root.join(user_path))
@@ -226,6 +220,7 @@ impl QartezServer {
             }
             fallible {
                 "qartez_find"        => qartez_find:        SoulFindParams,
+                "qartez_workspace"   => qartez_workspace:   SoulWorkspaceParams,
                 "qartez_read"        => qartez_read:        SoulReadParams,
                 "qartez_impact"      => qartez_impact:      SoulImpactParams,
                 "qartez_diff_impact" => qartez_diff_impact: SoulDiffImpactParams,
@@ -477,15 +472,15 @@ mod progressive_tests {
     }
 
     #[test]
-    fn total_tool_count_is_30() {
+    fn total_tool_count_is_31() {
         let server = test_server();
         let all = server.tool_router.list_all();
-        assert_eq!(all.len(), 30, "expected 30 tools, got {}", all.len());
+        assert_eq!(all.len(), 31, "expected 31 tools, got {}", all.len());
     }
 
     #[test]
     fn tier_sizes_are_correct() {
-        assert_eq!(tiers::TIER_CORE.len(), 8, "core tier");
+        assert_eq!(tiers::TIER_CORE.len(), 9, "core tier");
         assert_eq!(tiers::TIER_ANALYSIS.len(), 16, "analysis tier");
         assert_eq!(tiers::TIER_REFACTOR.len(), 3, "refactor tier");
         assert_eq!(tiers::TIER_META.len(), 2, "meta tier");

--- a/src/server/overview.rs
+++ b/src/server/overview.rs
@@ -246,6 +246,8 @@ impl super::QartezServer {
         }
 
         if !concise {
+            let roots = self.project_roots.read().unwrap();
+            let aliases = self.root_aliases.read().unwrap();
             for (path, symbols) in &file_symbols {
                 let exported: Vec<&crate::storage::models::SymbolRow> =
                     symbols.iter().filter(|s| s.is_exported).collect();
@@ -260,9 +262,15 @@ impl super::QartezServer {
                 out.push_str(&section_header);
 
                 let remaining = token_budget.saturating_sub(estimate_tokens(&out));
-                if let Some(elided) =
-                    elide_file_source(&self.project_root, path, symbols, remaining)
-                {
+
+                if let Some(elided) = elide_file_source(
+                    &self.project_root,
+                    &roots,
+                    &aliases,
+                    path,
+                    symbols,
+                    remaining,
+                ) {
                     out.push_str(&elided);
                 } else {
                     for sym in &exported {

--- a/src/server/params.rs
+++ b/src/server/params.rs
@@ -855,3 +855,22 @@ pub(super) struct ToolsParams {
     )]
     pub disable: Option<Vec<String>>,
 }
+
+#[derive(Debug, Deserialize, JsonSchema, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum WorkspaceAction {
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct SoulWorkspaceParams {
+    #[schemars(description = "Action to perform: add or remove a project domain")]
+    pub action: WorkspaceAction,
+    #[schemars(description = "The alias (domain name) for the project")]
+    pub alias: String,
+    #[schemars(
+        description = "The path to the project directory (required for 'add', optional for 'remove')"
+    )]
+    pub path: Option<String>,
+}

--- a/src/server/quality_tests.rs
+++ b/src/server/quality_tests.rs
@@ -271,6 +271,7 @@ fn populate_db(conn: &Connection) {
 
 fn setup() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     write_test_files(dir.path());
     let conn = setup_db();
     populate_db(&conn);
@@ -282,6 +283,7 @@ fn setup() -> (QartezServer, TempDir) {
 /// Used to stress-test unbounded output tools.
 fn setup_scale(leaf_count: usize) -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
@@ -541,7 +543,14 @@ fn elision_function_body_replaced() {
         owner_type: None,
     }];
 
-    let result = elide_file_source(dir.path(), "src/utils.rs", &symbols, 10000);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/utils.rs",
+        &symbols,
+        10000,
+    );
     assert!(
         result.is_some(),
         "should produce output for exported function"
@@ -576,7 +585,14 @@ fn elision_short_struct_shown_in_full() {
         owner_type: None,
     }];
 
-    let result = elide_file_source(dir.path(), "src/models.rs", &symbols, 10000);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/models.rs",
+        &symbols,
+        10000,
+    );
     assert!(result.is_some());
     let output = result.unwrap();
     // 4 lines (<=5), so full content should be shown
@@ -605,7 +621,14 @@ fn elision_long_type_truncated() {
         owner_type: None,
     }];
 
-    let result = elide_file_source(dir.path(), "src/models.rs", &symbols, 10000);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/models.rs",
+        &symbols,
+        10000,
+    );
     assert!(result.is_some());
     let output = result.unwrap();
     // 5 lines exactly (<=5 threshold), should show in full
@@ -634,7 +657,14 @@ fn elision_no_exported_symbols() {
         owner_type: None,
     }];
 
-    let result = elide_file_source(dir.path(), "src/utils.rs", &symbols, 10000);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/utils.rs",
+        &symbols,
+        10000,
+    );
     assert!(result.is_none(), "no exported symbols should return None");
 }
 
@@ -674,7 +704,14 @@ fn elision_budget_zero_minimal_output() {
         },
     ];
 
-    let result = elide_file_source(dir.path(), "src/utils.rs", &symbols, 0);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/utils.rs",
+        &symbols,
+        0,
+    );
     // With budget 0, the first symbol is still added (budget check is after),
     // then the loop breaks. Verify output doesn't grow unbounded.
     if let Some(output) = result {
@@ -722,7 +759,14 @@ fn elision_gap_marker_between_symbols() {
         },
     ];
 
-    let result = elide_file_source(dir.path(), "src/utils.rs", &symbols, 10000);
+    let result = elide_file_source(
+        dir.path(),
+        &[],
+        &std::collections::HashMap::new(),
+        "src/utils.rs",
+        &symbols,
+        10000,
+    );
     assert!(result.is_some());
     let output = result.unwrap();
     assert!(
@@ -1286,6 +1330,7 @@ fn qartez_read_accepts_offset_alias() {
 #[test]
 fn qartez_grep_search_bodies_hits_identifier_inside_body() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
     fs::write(
@@ -1571,6 +1616,7 @@ fn qartez_outline_concise_smaller() {
 #[test]
 fn qartez_outline_shows_struct_fields_nested_under_parent() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
     fs::write(
@@ -1621,6 +1667,7 @@ fn qartez_outline_shows_struct_fields_nested_under_parent() {
 #[test]
 fn qartez_outline_shows_tuple_struct_fields() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
     fs::write(
@@ -2340,6 +2387,7 @@ fn scale_qartez_find_common_name() {
 #[test]
 fn edge_empty_db_qartez_map() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let output = server.build_overview(20, 4000, None, None, false, false);
@@ -2350,6 +2398,7 @@ fn edge_empty_db_qartez_map() {
 #[test]
 fn edge_empty_db_qartez_stats() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let result = server
@@ -2361,6 +2410,7 @@ fn edge_empty_db_qartez_stats() {
 #[test]
 fn edge_empty_db_qartez_grep() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let result = server
@@ -2378,6 +2428,7 @@ fn edge_empty_db_qartez_grep() {
 #[test]
 fn edge_empty_db_qartez_unused() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let result = server
@@ -2660,6 +2711,7 @@ fn monotonicity_qartez_grep() {
 /// touch the local alias spelling or its call sites.
 fn setup_aliased_rename() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
@@ -2930,6 +2982,7 @@ fn rewrite_mod_decl_word_boundary_safe() {
 #[test]
 fn find_parent_mod_file_flat_sibling() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     fs::create_dir_all(dir.path().join("src")).unwrap();
     fs::write(dir.path().join("src/lib.rs"), "mod foo;\n").unwrap();
     fs::write(dir.path().join("src/foo.rs"), "").unwrap();
@@ -2941,6 +2994,7 @@ fn find_parent_mod_file_flat_sibling() {
 #[test]
 fn find_parent_mod_file_nested_mod_rs() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     fs::create_dir_all(dir.path().join("src/a")).unwrap();
     fs::write(dir.path().join("src/lib.rs"), "mod a;\n").unwrap();
     fs::write(dir.path().join("src/a/mod.rs"), "mod b;\n").unwrap();
@@ -2953,6 +3007,7 @@ fn find_parent_mod_file_nested_mod_rs() {
 #[test]
 fn find_parent_mod_file_rejects_non_rust() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     assert!(find_parent_mod_file(dir.path(), "src/config.toml").is_none());
 }
 
@@ -3025,6 +3080,7 @@ fn qartez_wiki_assigns_every_file_to_exactly_one_cluster() {
 
 fn setup_with_complexity() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     write_test_files(dir.path());
     let conn = setup_db();
 
@@ -3205,6 +3261,7 @@ fn qartez_hotspots_concise_smaller() {
 #[test]
 fn qartez_hotspots_empty_db_no_panic() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let out = server
@@ -3752,6 +3809,7 @@ fn qartez_hotspots_threshold_above_10_clamped() {
 
 fn setup_with_clones() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
@@ -3882,6 +3940,7 @@ fn qartez_clones_concise_smaller() {
 #[test]
 fn qartez_clones_no_clones_message() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 300);
     let out = server
@@ -4154,6 +4213,7 @@ fn qartez_boundaries_detects_violation() {
 #[test]
 fn qartez_trend_no_git_depth_returns_error() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 0);
     let result = server.qartez_trend(Parameters(SoulTrendParams {
@@ -4169,6 +4229,7 @@ fn qartez_trend_no_git_depth_returns_error() {
 #[test]
 fn qartez_trend_nonexistent_file_returns_empty() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
     // Need at least one commit so HEAD exists.
     fs::write(dir.path().join("dummy.rs"), "pub fn x() {}\n").unwrap();
@@ -4193,6 +4254,7 @@ fn qartez_trend_nonexistent_file_returns_empty() {
 #[test]
 fn qartez_trend_with_git_history() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
     // Commit 1: simple function.
@@ -4236,6 +4298,7 @@ fn qartez_trend_with_git_history() {
 #[test]
 fn qartez_trend_concise_format() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
 
     fs::write(dir.path().join("lib.rs"), "pub fn f() -> bool { true }\n").unwrap();
@@ -4334,6 +4397,7 @@ fn all_tools_have_dispatch_entries() {
 /// runs full_index, and constructs a QartezServer ready for destructive ops.
 fn setup_destructive() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 
@@ -4683,6 +4747,7 @@ fn rename_file_apply_into_subdirectory() {
 
 fn setup_with_risk() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     let tests_dir = dir.path().join("tests");
     fs::create_dir_all(&src).unwrap();
@@ -5321,6 +5386,7 @@ fn qartez_diff_impact_risk_highest_risk_has_reason() {
 #[test]
 fn qartez_knowledge_no_git_depth_returns_error() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 0);
     let result = server.qartez_knowledge(Parameters(SoulKnowledgeParams {
@@ -5337,6 +5403,7 @@ fn qartez_knowledge_no_git_depth_returns_error() {
 #[test]
 fn qartez_knowledge_empty_db_returns_no_files() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let conn = setup_db();
     let server = QartezServer::new(conn, dir.path().to_path_buf(), 100);
     let result = server.qartez_knowledge(Parameters(SoulKnowledgeParams {
@@ -5357,6 +5424,7 @@ fn qartez_knowledge_empty_db_returns_no_files() {
 #[test]
 fn qartez_knowledge_file_level_with_repo() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     // Create a git repo with a file
     let repo = git2::Repository::init(dir.path()).unwrap();
     let src = dir.path().join("src");
@@ -5398,6 +5466,7 @@ fn qartez_knowledge_file_level_with_repo() {
 #[test]
 fn qartez_knowledge_module_level() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
@@ -5437,6 +5506,7 @@ fn qartez_knowledge_module_level() {
 #[test]
 fn qartez_knowledge_concise_format() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
     fs::write(dir.path().join("lib.rs"), "pub fn foo() {}\n").unwrap();
     let mut index = repo.index().unwrap();
@@ -5472,6 +5542,7 @@ fn qartez_knowledge_concise_format() {
 #[test]
 fn qartez_knowledge_output_format_detailed_validated() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
@@ -5530,6 +5601,7 @@ fn qartez_knowledge_output_format_detailed_validated() {
 #[test]
 fn qartez_knowledge_file_path_prefix_filter() {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let repo = git2::Repository::init(dir.path()).unwrap();
     let src = dir.path().join("src");
     let tests_dir = dir.path().join("tests");
@@ -5834,6 +5906,7 @@ fn qartez_calls_no_symbol_errors() {
 
 fn setup_test_gaps_fixture() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     let tests_dir = dir.path().join("tests");
     fs::create_dir_all(&src).unwrap();
@@ -6147,6 +6220,7 @@ fn qartez_test_gaps_limit_truncates() {
 
 fn setup_smells_fixture() -> (QartezServer, TempDir) {
     let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
     let src = dir.path().join("src");
     fs::create_dir_all(&src).unwrap();
 

--- a/src/server/tiers.rs
+++ b/src/server/tiers.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, RwLock};
 /// sufficient for the vast majority of code-exploration sessions.
 pub(super) const TIER_CORE: &[&str] = &[
     "qartez_map",
+    "qartez_workspace",
     "qartez_find",
     "qartez_grep",
     "qartez_read",

--- a/src/server/tools/mod.rs
+++ b/src/server/tools/mod.rs
@@ -37,10 +37,12 @@ mod tools_meta;
 mod trend;
 mod unused;
 mod wiki;
+mod workspace;
 
 impl QartezServer {
     pub(super) fn tool_router() -> ToolRouter<Self> {
         Self::qartez_map_router()
+            + Self::qartez_workspace_router()
             + Self::qartez_find_router()
             + Self::qartez_read_router()
             + Self::qartez_impact_router()

--- a/src/server/tools/security.rs
+++ b/src/server/tools/security.rs
@@ -83,7 +83,11 @@ impl QartezServer {
                 .file_path
                 .as_ref()
                 .map(|s| crate::index::to_forward_slash(s.clone())),
-            project_roots: self.project_roots.clone(),
+            project_roots: self
+                .project_roots
+                .read()
+                .map_err(|e| e.to_string())?
+                .clone(),
         };
 
         let findings = scan(&conn, &rules, &opts);

--- a/src/server/tools/workspace.rs
+++ b/src/server/tools/workspace.rs
@@ -1,0 +1,137 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::service::RequestContext;
+use rmcp::{RoleServer, tool, tool_router};
+
+use super::super::QartezServer;
+use super::super::params::*;
+
+use crate::config::expand_path;
+use crate::index;
+use crate::storage::{read, write};
+
+#[tool_router(router = qartez_workspace_router, vis = "pub(super)")]
+impl QartezServer {
+    #[tool(
+        name = "qartez_workspace",
+        description = "Manage project domains (workspaces) dynamically. Add or remove external directories with custom aliases.",
+        annotations(
+            title = "Workspace Management",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    pub(in crate::server) fn qartez_workspace(
+        &self,
+        Parameters(params): Parameters<SoulWorkspaceParams>,
+    ) -> Result<String, String> {
+        match params.action {
+            WorkspaceAction::Add => self.add_workspace(&params.alias, params.path.as_deref()),
+            WorkspaceAction::Remove => self.remove_workspace(&params.alias),
+        }
+    }
+
+    fn add_workspace(&self, alias: &str, path_str: Option<&str>) -> Result<String, String> {
+        let Some(path_str) = path_str else {
+            return Err("Path is required for 'add' action".to_string());
+        };
+
+        let path = expand_path(path_str, &self.project_root);
+        let canonical_path = path
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve path '{path_str}': {e}"))?;
+
+        if !canonical_path.is_dir() {
+            return Err(format!(
+                "Path '{}' is not a directory",
+                canonical_path.display()
+            ));
+        }
+
+        let config_path = self.project_root.join(".qartez").join("workspace.toml");
+        let content = std::fs::read_to_string(&config_path).unwrap_or_default();
+        let mut doc: toml_edit::DocumentMut = content.parse().unwrap_or_default();
+        let workspaces = doc.entry("workspaces").or_insert(toml_edit::table());
+        if let Some(table) = workspaces.as_table_mut() {
+            table.insert(alias, toml_edit::value(path_str));
+        }
+        if let Some(parent) = config_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        std::fs::write(&config_path, doc.to_string()).map_err(|e| e.to_string())?;
+
+        {
+            let mut roots = self.project_roots.write().map_err(|e| e.to_string())?;
+            let mut aliases = self.root_aliases.write().map_err(|e| e.to_string())?;
+            if !roots.contains(&canonical_path) {
+                roots.push(canonical_path.clone());
+            }
+            aliases.insert(canonical_path.clone(), alias.to_string());
+        }
+
+        let extra_known: HashSet<String> = {
+            let conn = self.db.lock().map_err(|e| e.to_string())?;
+            read::get_all_files(&conn)
+                .map_err(|e| e.to_string())?
+                .into_iter()
+                .map(|f| f.path)
+                .collect()
+        };
+
+        {
+            let conn = self.db.lock().map_err(|e| e.to_string())?;
+            index::full_index_root(&conn, &canonical_path, false, alias, &extra_known)
+                .map_err(|e| e.to_string())?;
+        }
+
+        Ok(format!("Added domain '{alias}' at '{path_str}'."))
+    }
+
+    fn remove_workspace(&self, alias: &str) -> Result<String, String> {
+        let mut path_to_remove: Option<PathBuf> = None;
+
+        {
+            let mut roots = self.project_roots.write().map_err(|e| e.to_string())?;
+            let mut aliases = self.root_aliases.write().map_err(|e| e.to_string())?;
+
+            for (path, a) in aliases.iter() {
+                if a == alias {
+                    path_to_remove = Some(path.clone());
+                    break;
+                }
+            }
+
+            if let Some(ref path) = path_to_remove {
+                aliases.remove(path);
+                roots.retain(|r| r != path);
+            } else {
+                return Err(format!("Domain '{alias}' not found in workspace"));
+            }
+        }
+
+        let config_path = self.project_root.join(".qartez").join("workspace.toml");
+        if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path).unwrap_or_default();
+            if let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>()
+                && let Some(workspaces) = doc.get_mut("workspaces").and_then(|w| w.as_table_mut())
+            {
+                workspaces.remove(alias);
+                let _ = std::fs::write(&config_path, doc.to_string());
+            }
+        }
+
+        {
+            let conn = self.db.lock().map_err(|e| e.to_string())?;
+            write::delete_files_by_prefix(&conn, alias).map_err(|e| e.to_string())?;
+        }
+
+        Ok(format!(
+            "Removed domain '{alias}'. All associated symbols and files have been purged from the index."
+        ))
+    }
+}

--- a/src/storage/write.rs
+++ b/src/storage/write.rs
@@ -132,6 +132,30 @@ pub fn delete_file_data(conn: &Connection, file_id: i64) -> Result<()> {
     Ok(())
 }
 
+/// Delete all files whose path starts with `alias/` (e.g. a workspace domain),
+/// cleaning up FTS and embedding tables before the cascade removes symbols.
+pub fn delete_files_by_prefix(conn: &Connection, alias: &str) -> Result<usize> {
+    let pattern = format!("{alias}/%");
+    conn.execute(
+        "DELETE FROM symbols_fts WHERE rowid IN \
+         (SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.path LIKE ?1)",
+        [&pattern],
+    )?;
+    conn.execute(
+        "DELETE FROM symbols_body_fts WHERE rowid IN \
+         (SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.path LIKE ?1)",
+        [&pattern],
+    )?;
+    #[cfg(feature = "semantic")]
+    conn.execute(
+        "DELETE FROM symbol_embeddings WHERE rowid IN \
+         (SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.path LIKE ?1)",
+        [&pattern],
+    )?;
+    let n = conn.execute("DELETE FROM files WHERE path LIKE ?1", [&pattern])?;
+    Ok(n)
+}
+
 /// Clear a file's derived content (symbols, outgoing edges, FTS entries,
 /// unused-export markers) without deleting the file row itself. This
 /// preserves the `file_id` and incoming edges from other files, which is

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -38,6 +38,7 @@ impl Formatter for Settings {
 
     let config = Config {
         project_roots: vec![dir.path().to_path_buf()],
+        root_aliases: std::collections::HashMap::new(),
         primary_root: dir.path().to_path_buf(),
         db_path: db_dir.join("index.db"),
         reindex: false,
@@ -289,6 +290,7 @@ fn cli_stats_no_project() {
     fs::create_dir_all(&db_dir).unwrap();
     let config = Config {
         project_roots: vec![dir.path().to_path_buf()],
+        root_aliases: std::collections::HashMap::new(),
         primary_root: dir.path().to_path_buf(),
         db_path: db_dir.join("index.db"),
         reindex: false,


### PR DESCRIPTION
## Summary

Adds two related features for managing multi-root projects:

1. `.qartez/workspace.toml` — declarative workspace config Parse a `[workspaces]` table at startup to register external directories with custom aliases (domain prefixes). Supports absolute paths, relative paths, and `~/` home expansion. Aliases override the default folder-name prefix in all path results and the index. Agents are able to distinguish between the Aliases so porting features from old versions or cross-checking becomes possible.

2. `qartez_workspace` MCP tool / `qartez workspace` CLI Add or remove workspace domains at runtime without restarting. `add` resolves and indexes the directory synchronously, updates `.qartez/workspace.toml`, and wires the new root into the server's in-memory state. `remove` purges all associated files and symbols from the index in a single bulk SQL pass.

## Usage

Two new ways to manage multi-root workspaces at runtime, without restarting or editing config by hand.

**MCP tool (agent session)**
```
qartez_workspace(action="add", alias="MyApp", path="../my-app")
qartez_workspace(action="remove", alias="MyApp")
```

**CLI**
```
qartez workspace add MyApp ../my-app
qartez workspace remove MyApp
```

Paths support `~/`, relative, and absolute forms. After `add`, all tools (`qartez_map`, `qartez_find`, `qartez_grep`, …) show files prefixed with the alias (e.g. `MyApp/src/lib.rs`). After `remove`, all associated files and symbols are purged from the index in a single bulk pass.

Workspaces persist across restarts via `.qartez/workspace.toml` — the same file you can also write by hand (see updated `docs/configuration.md`).                 
            
Internal cleanup bundled with the feature:
- Extract `resolve_prefixed_path` helper (was duplicated in `helpers.rs` and `mod.rs::safe_resolve`)
- Extract `expand_path` helper in `config.rs` (was duplicated in config and workspace tool)
- Add `write::delete_files_by_prefix` for O(1) bulk domain purge instead of N individual per-file deletes
- Compute `root_prefix` once per root in `full_index_multi`
- Hoist `RwLock` guards above the file loop in `overview.rs`
- Use typed `WorkspaceAction` enum in CLI (was `String`)
- Add `.git` sentinel dirs to test fixtures that need git detection

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] New language support

## How has this been tested?

- [x] Existing tests pass (`cargo test`)
- [x] New tests added for this change

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] `cargo clippy` produces no new warnings
- [x] `cargo test` passes (1000+ tests, should take ~2 seconds)
- [x] I have added tests that cover my changes
- [x] I have updated documentation where needed
- [x] My changes generate no new compiler warnings

## Additional context

Note: no integration test covering the qartez_workspace add/remove flow end-to-end