### PR TITLE
fix(workspace): resolve indexed file paths via safe_resolve

### DIFF
--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -43,7 +43,7 @@ impl super::QartezServer {
     /// Read a file's mtime in nanoseconds, or `None` if the file is missing
     /// or the filesystem does not expose a modification time.
     pub(super) fn file_mtime_ns(&self, rel_path: &str) -> Option<i64> {
-        let abs_path = self.project_root.join(rel_path);
+        let abs_path = self.safe_resolve(rel_path).ok()?;
         std::fs::metadata(&abs_path)
             .ok()?
             .modified()
@@ -69,7 +69,7 @@ impl super::QartezServer {
             return Some(src.clone());
         }
 
-        let abs_path = self.project_root.join(rel_path);
+        let abs_path = self.safe_resolve(rel_path).ok()?;
         let raw = std::fs::read_to_string(&abs_path).ok()?;
         let arc = Arc::new(raw);
 

--- a/src/server/quality_tests.rs
+++ b/src/server/quality_tests.rs
@@ -1324,6 +1324,67 @@ fn qartez_read_accepts_offset_alias() {
 }
 
 // =========================================================================
+// Section 7b: qartez_read - workspace alias path resolution
+// =========================================================================
+
+#[test]
+fn qartez_read_resolves_symbol_via_workspace_alias() {
+    // Regression: symbol reads used project_root.join(file.path) instead of
+    // safe_resolve, so any DB path prefixed with a workspace alias resolved
+    // against the primary root and returned "No such file or directory".
+    let primary_dir = TempDir::new().unwrap();
+    fs::create_dir(primary_dir.path().join(".git")).unwrap();
+    write_test_files(primary_dir.path());
+
+    let ws_dir = TempDir::new().unwrap();
+    let ws_src = ws_dir.path().join("src");
+    fs::create_dir_all(&ws_src).unwrap();
+    fs::write(ws_src.join("widget.rs"), "pub fn ws_func() -> u32 { 42 }\n").unwrap();
+
+    let conn = setup_db();
+    populate_db(&conn);
+    let ws_file_id = write::upsert_file(&conn, "WS/src/widget.rs", 1000, 50, "rust", 1).unwrap();
+    write::insert_symbols(
+        &conn,
+        ws_file_id,
+        &[SymbolInsert {
+            name: "ws_func".into(),
+            kind: "function".into(),
+            line_start: 1,
+            line_end: 1,
+            signature: Some("pub fn ws_func() -> u32".into()),
+            is_exported: true,
+            shape_hash: None,
+            parent_idx: None,
+            unused_excluded: false,
+            complexity: None,
+            owner_type: None,
+        }],
+    )
+    .unwrap();
+
+    let primary = primary_dir.path().to_path_buf();
+    let ws_root = ws_dir.path().to_path_buf();
+    let mut aliases = std::collections::HashMap::new();
+    aliases.insert(ws_root.clone(), "WS".to_string());
+    let server =
+        QartezServer::with_roots(conn, primary.clone(), vec![primary, ws_root], aliases, 300);
+
+    let result = server
+        .qartez_read(Parameters(SoulReadParams {
+            symbol_name: Some("ws_func".into()),
+            ..Default::default()
+        }))
+        .expect("ws_func should be readable via workspace alias");
+
+    assert!(result.contains("ws_func"), "result: {result}");
+    assert!(
+        result.contains("42"),
+        "should contain function body, result: {result}"
+    );
+}
+
+// =========================================================================
 // Section 8: Tool Handler - qartez_grep
 // =========================================================================
 

--- a/src/server/tools/mv.rs
+++ b/src/server/tools/mv.rs
@@ -84,7 +84,7 @@ impl QartezServer {
         }
 
         let (sym, source_file) = &results[0];
-        let source_abs = self.project_root.join(&source_file.path);
+        let source_abs = self.safe_resolve(&source_file.path)?;
         let target_abs = self.safe_resolve(&params.to_file)?;
 
         if source_file.path != params.to_file
@@ -226,7 +226,10 @@ impl QartezServer {
         let mut import_updates = 0;
         let mut failed_writes: Vec<String> = Vec::new();
         for (importer_path, _) in &importer_files {
-            let importer_abs = self.project_root.join(importer_path);
+            let importer_abs = match self.safe_resolve(importer_path) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
             let content = match std::fs::read_to_string(&importer_abs) {
                 Ok(c) => c,
                 Err(_) => continue,

--- a/src/server/tools/read.rs
+++ b/src/server/tools/read.rs
@@ -190,7 +190,7 @@ impl QartezServer {
 
         for (_idx, filtered) in &per_query {
             for (sym, file) in filtered {
-                let abs_path = self.project_root.join(&file.path);
+                let abs_path = self.safe_resolve(&file.path)?;
                 let source = match std::fs::read_to_string(&abs_path) {
                     Ok(s) => s,
                     Err(e) => return Err(format!("Cannot read {}: {e}", abs_path.display())),

--- a/src/server/tools/rename.rs
+++ b/src/server/tools/rename.rs
@@ -183,7 +183,7 @@ impl QartezServer {
             // `files_to_scan` but was skipped during the AST walk above;
             // those files must stay untouched.
             for rel_path in &files_touched {
-                let abs_path = self.project_root.join(rel_path);
+                let abs_path = self.safe_resolve(rel_path)?;
                 let content = std::fs::read_to_string(&abs_path)
                     .map_err(|e| format!("Cannot read {}: {e}", abs_path.display()))?;
 

--- a/src/server/tools/rename_file.rs
+++ b/src/server/tools/rename_file.rs
@@ -111,7 +111,10 @@ impl QartezServer {
             None
         };
         for importer_path in &importer_paths {
-            let importer_abs = self.project_root.join(importer_path);
+            let importer_abs = match self.safe_resolve(importer_path) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
             let content = match std::fs::read_to_string(&importer_abs) {
                 Ok(c) => c,
                 Err(_) => continue,
@@ -139,8 +142,8 @@ impl QartezServer {
         let mut mod_rewrite_note = String::new();
         if old_rel_stem != new_rel_stem
             && let Some(parent_rel) = find_parent_mod_file(&self.project_root, &params.from)
+            && let Ok(parent_abs) = self.safe_resolve(&parent_rel.to_string_lossy())
         {
-            let parent_abs = self.project_root.join(&parent_rel);
             if let Ok(content) = std::fs::read_to_string(&parent_abs) {
                 let rewritten = rewrite_mod_decl(&content, &old_rel_stem, &new_rel_stem);
                 if rewritten != content {


### PR DESCRIPTION
## Summary

Fixes a bug where `qartez_read` (and other tools that access indexed files) resolved paths against `project_root` instead of going through `safe_resolve`, causing all reads of workspace-alias-prefixed paths to fail with "No such file or directory".

**Root cause:** Seven call sites across `read.rs`, `mv.rs`, `rename_file.rs`, `rename.rs`, and `cache.rs` used `self.project_root.join(path)` directly for DB-indexed file paths. `safe_resolve` is the only method that applies multi-root alias routing (via `helpers::resolve_prefixed_path`), so any path prefixed with a workspace alias (e.g. `FinVR/app/src/…`) was silently resolved against the primary project root and the read failed.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New language support

## How has this been tested?

Added a regression test `qartez_read_resolves_symbol_via_workspace_alias` in `src/server/quality_tests.rs` that:

1. Creates a primary project root and a separate workspace directory.
2. Writes a source file (`WS/src/widget.rs`) to the workspace directory and registers it in the DB with the alias-prefixed path.
3. Constructs a `QartezServer` with both roots and the alias mapping (`WS → ws_dir`).
4. Calls `qartez_read` for a symbol in the workspace file and asserts the source body is returned — previously this produced "No such file or directory" because the path was resolved against the primary root.

- [x] Existing tests pass (`cargo test`)
- [x] New tests added for this change

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines (`cargo fmt`)
- [x] `cargo clippy` produces no new warnings
- [x] `cargo test` passes (1000+ tests, should take ~2 seconds)
- [x] I have added tests that cover my changes
- [ ] I have updated documentation where needed
- [x] My changes generate no new compiler warnings

## Additional context

The fix was verified end-to-end: after installing the patched binary, `qartez_read` correctly resolves to the original file location rather than the qartez-mcp project root.

The same class of bug was present (but untested) in the destructive tools `qartez_move` and `qartez_rename_file`, and in the parse cache (`cached_source` / `file_mtime_ns`). All are fixed in this PR.
